### PR TITLE
Split the MediaFetcher into MediaDownloader and MediaUploader

### DIFF
--- a/fa_search_bot/config.py
+++ b/fa_search_bot/config.py
@@ -39,14 +39,19 @@ class WeasylConfig:
 class SubscriptionWatcherConfig:
     enabled: bool
     num_data_fetchers: int
-    num_media_fetchers: int
+    num_media_downloaders: int
+    num_media_uploaders: int
+
+    def total_num_task_runners(self) -> int:
+        return self.num_data_fetchers + self.num_media_downloaders + self.num_media_uploaders
 
     @classmethod
     def from_dict(cls, conf: dict) -> "SubscriptionWatcherConfig":
         return cls(
             enabled=conf.get("enabled", True),
             num_data_fetchers=conf.get("num_data_fetchers", 2),
-            num_media_fetchers=conf.get("num_media_fetchers", 2),
+            num_media_downloaders=conf.get("num_media_downloaders", 2),
+            num_media_uploaders=conf.get("num_media_uploaders", 1),
         )
 
 

--- a/fa_search_bot/config.py
+++ b/fa_search_bot/config.py
@@ -4,6 +4,11 @@ import dataclasses
 import json
 from typing import Optional
 
+DEFAULT_NUM_DATA_FETCHERS = 2
+DEFAULT_NUM_MEDIA_DOWNLOADERS = 2
+DEFAULT_NUM_MEDIA_UPLOADERS = 1
+DEFAULT_MAX_READY_FOR_UPLOAD = 100    # Maximum number of submissions which should be ready for media upload, to prevent data being too stale by the time it comes to upload, especially if catching up on backlog
+
 
 @dataclasses.dataclass
 class TelegramConfig:
@@ -41,6 +46,7 @@ class SubscriptionWatcherConfig:
     num_data_fetchers: int
     num_media_downloaders: int
     num_media_uploaders: int
+    max_ready_for_upload: int
 
     def total_num_task_runners(self) -> int:
         return self.num_data_fetchers + self.num_media_downloaders + self.num_media_uploaders
@@ -49,9 +55,10 @@ class SubscriptionWatcherConfig:
     def from_dict(cls, conf: dict) -> "SubscriptionWatcherConfig":
         return cls(
             enabled=conf.get("enabled", True),
-            num_data_fetchers=conf.get("num_data_fetchers", 2),
-            num_media_downloaders=conf.get("num_media_downloaders", 2),
-            num_media_uploaders=conf.get("num_media_uploaders", 1),
+            num_data_fetchers=conf.get("num_data_fetchers", DEFAULT_NUM_DATA_FETCHERS),
+            num_media_downloaders=conf.get("num_media_downloaders", DEFAULT_NUM_MEDIA_DOWNLOADERS),
+            num_media_uploaders=conf.get("num_media_uploaders", DEFAULT_NUM_MEDIA_UPLOADERS),
+            max_ready_for_upload=conf.get("max_ready_for_upload", DEFAULT_MAX_READY_FOR_UPLOAD),
         )
 
 

--- a/fa_search_bot/functionalities/subscriptions.py
+++ b/fa_search_bot/functionalities/subscriptions.py
@@ -216,7 +216,7 @@ class BlocklistFunctionality(BotFunctionality):
     def _remove_from_blocklist(self, destination: int, query: str) -> str:
         self.usage_counter.labels(function=self.USE_CASE_REMOVE).inc()
         try:
-            self.watcher.blocklists.get(destination, set()).remove(query)
+            self.watcher.blocklists[destination].remove(query)
             self.watcher.save_to_json()
             return f'Removed tag from blocklist: "{query}".\n{self._list_blocklisted_tags(destination)}'
         except KeyError:
@@ -224,6 +224,6 @@ class BlocklistFunctionality(BotFunctionality):
 
     def _list_blocklisted_tags(self, destination: int) -> str:
         self.usage_counter.labels(function=self.USE_CASE_LIST).inc()
-        blocklist = self.watcher.blocklists.get(destination, set())
-        tags_list = "\n".join([f"- {tag}" for tag in blocklist])
+        blocklist = self.watcher.blocklists.get(destination)
+        tags_list = "\n".join([f"- {tag}" for tag in blocklist.blocklists.keys()])
         return f"Current blocklist for this chat:\n{tags_list}"

--- a/fa_search_bot/sites/furaffinity/fa_export_api.py
+++ b/fa_search_bot/sites/furaffinity/fa_export_api.py
@@ -89,9 +89,10 @@ class FAExportAPI:
         return self._session
 
     async def _api_request(self, path: str, endpoint_label: Endpoint) -> aiohttp.ClientResponse:
-        path = path.lstrip("/")
+        path = "/"+path.lstrip("/")
+        logger.debug("Making FAExport API request: %s", path)
         with api_request_times.labels(endpoint=endpoint_label.value).time():
-            async with self.session.get(f"/{path}") as resp:
+            async with self.session.get(path) as resp:
                 await resp.read()
         error_type = None
         if resp.status != 200:

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -12,12 +12,12 @@ import uuid
 from abc import ABC, abstractmethod
 from asyncio import Lock
 from contextlib import contextmanager, asynccontextmanager
-from typing import TYPE_CHECKING, Callable, TypeVar, Generator, Tuple, Dict, List, ContextManager, AsyncGenerator
+from typing import TYPE_CHECKING, Callable, TypeVar, Generator, Tuple, Dict, List, AsyncGenerator
 
 import aiohttp
 import docker
 from PIL import Image, UnidentifiedImageError, ImageFile
-from aiohttp import ClientError, ClientResponseError
+from aiohttp import ClientResponseError
 from prometheus_client import Counter, Summary
 from prometheus_client.metrics import Histogram
 from telethon import Button
@@ -394,7 +394,7 @@ IMG_EDIT_LOCK = Lock()
 
 
 @asynccontextmanager
-async def open_image(img_path: str, *, load_truncated: bool = False) -> ContextManager[Image]:
+async def open_image(img_path: str, *, load_truncated: bool = False) -> AsyncGenerator[Image]:
     async with IMG_EDIT_LOCK:
         try:
             ImageFile.LOAD_TRUNCATED_IMAGES = load_truncated
@@ -505,7 +505,8 @@ class Sendable(InlineSendable):
     ]  # These should be converted to mp4, without sound, if they are animated
     EXTENSIONS_VIDEO = ["webm"]  # These should be converted to mp4, with sound
 
-    EXTENSIONS_AUTO_DOCUMENT = ["pdf"]  # Telegram can embed these as documents
+    EXTENSIONS_AUTO_DOCUMENT = ["pdf"]  # Telegram can embed these as documents automatically from the URL
+    EXTENSIONS_PDF = ["pdf"]  # Telegram can embed these as documents
     EXTENSIONS_AUDIO = ["mp3"]  # Telegram can embed these as audio
     EXTENSIONS_PHOTO = ["jpg", "jpeg"]  # Telegram can embed these as images
     # Maybe use these for labels
@@ -607,53 +608,85 @@ class Sendable(InlineSendable):
             return sent_sub
         return send_partial
 
-    async def upload(self, client: TelegramClient) -> UploadedMedia:
+    async def download(self) -> tuple[DownloadedFile, SendSettings]:
         settings = SendSettings(CaptionSettings())
         ext = self.download_file_ext
 
-        # Handle potentially animated formats
-        if ext in self.EXTENSIONS_ANIMATED:
-            async with _downloaded_file(self.download_url) as dl_file:
-                if await self._is_animated(dl_file.dl_path):
-                    return await self._upload_video(client, dl_file, settings)
-                else:
-                    return await self._upload_image(client, dl_file, settings)
-        # Handle photos
-        if ext in self.EXTENSIONS_PHOTO:
-            async with _downloaded_file(self.download_url) as dl_file:
-                return await self._upload_image(client, dl_file, settings)
-        # Handle videos, which can be made pretty
-        if ext in self.EXTENSIONS_VIDEO:
-            async with _downloaded_file(self.download_url) as dl_file:
-                sendable_animated.labels(site_code=self.site_id).inc()
-                return await self._upload_video(client, dl_file, settings)
+        # Handle potentially animated formats, photos, and videos
+        if ext in self.EXTENSIONS_ANIMATED + self.EXTENSIONS_PHOTO + self.EXTENSIONS_VIDEO:
+            return await _download_file(self.download_url), settings
         # Everything else is a file, send with title and author
         settings.caption.title = True
         settings.caption.author = True
-        # Special handling, if it's small enough
+        # Special handling, if it's within telegram file size limits
         with time_taken_fetching_filesize.time():
             dl_filesize = await self.download_file_size()
         if dl_filesize < self.SIZE_LIMIT_DOCUMENT:
             # Handle pdfs, which can be sent as documents
             if ext in self.EXTENSIONS_AUTO_DOCUMENT:
                 settings.force_doc = True
-                return UploadedMedia(self.submission_id, _url_to_media(self.download_url, False), settings)
+                return await _download_file(self.download_url), settings
             # Handle audio
             if ext in self.EXTENSIONS_AUDIO:
-                async with _downloaded_file(self.download_url) as dl_file:
-                    return await self._upload_audio(client, dl_file, settings)
+                return await _download_file(self.download_url), settings
         # Handle files telegram can't handle
         sendable_other.labels(site_code=self.site_id).inc()
         settings.caption.direct_link = True
         try:
-            async with _downloaded_file(self.preview_image_url) as dl_file:
-                return await self._upload_image(client, dl_file, settings)
+            return await _download_file(self.preview_image_url), settings
         except DownloadError as e:
             # Sometimes with stories, the preview image does not exist, so use thumbnail
             if e.exc.status == 404:
-                async with _downloaded_file(self.thumbnail_url) as dl_file:
-                    return await self._upload_image(client, dl_file, settings)
+                return await _download_file(self.thumbnail_url), settings
             raise e
+
+    async def upload_only(
+            self,
+            client: TelegramClient,
+            dl_file: DownloadedFile,
+            send_settings: SendSettings,
+    ) -> UploadedMedia:
+        ext = dl_file.file_ext()
+
+        # Handle potentially animated formats
+        if ext in self.EXTENSIONS_ANIMATED:
+            if await self._is_animated(dl_file.dl_path):
+                return await self._upload_video(client, dl_file, send_settings)
+            else:
+                return await self._upload_image(client, dl_file, send_settings)
+        # Handle photos
+        if ext in self.EXTENSIONS_PHOTO:
+            return await self._upload_image(client, dl_file, send_settings)
+        # Handle videos, which can be made pretty
+        if ext in self.EXTENSIONS_VIDEO:
+            sendable_animated.labels(site_code=self.site_id).inc()
+            return await self._upload_video(client, dl_file, send_settings)
+        # Everything else is a file, send with title and author (This might have been set by download already)
+        send_settings.caption.title = True
+        send_settings.caption.author = True
+        # Special handling, if it's small enough
+        dl_filesize = dl_file.filesize
+        if dl_filesize < self.SIZE_LIMIT_DOCUMENT:
+            # Handle pdfs, which can be sent as documents
+            if ext in self.EXTENSIONS_PDF:
+                send_settings.force_doc = True
+                return await self._upload_pdf(client, dl_file, send_settings)
+            # Handle audio
+            if ext in self.EXTENSIONS_AUDIO:
+                return await self._upload_audio(client, dl_file, send_settings)
+        # Raise an exception for other formats, as download should have given something that upload only can handle.
+        raise CantSendFileType(f"Not sure how to send file with extension: {ext}")
+
+    async def upload(self, client: TelegramClient) -> UploadedMedia:
+        dl_file, send_settings = await self.download()
+        uploaded_media: Optional[UploadedMedia] = None
+        try:
+            uploaded_media = await self.upload_only(client, dl_file, send_settings)
+        finally:
+            try_delete_sandbox_file(dl_file.dl_path)
+            if uploaded_media:
+                return uploaded_media
+            raise CantSendFileType("Failed to upload file type")
 
     def _save_to_debug(self, file_path: str) -> None:
         os.makedirs("debug", exist_ok=True)
@@ -774,6 +807,28 @@ class Sendable(InlineSendable):
             ],
             thumb=thumb_handle,
             force_file=False,
+        )
+        return UploadedMedia(self.submission_id, media, settings)
+
+    async def _upload_pdf(
+            self,
+            client: TelegramClient,
+            dl_file: DownloadedFile,
+            settings: SendSettings,
+    ) -> UploadedMedia:
+        sendable_auto_doc.labels(site_code=self.site_id).inc()
+        async with _downloaded_file(self.thumbnail_url) as thumb_file:
+            with time_taken_uploading_file.time():
+                file_handle = await client.upload_file(dl_file.dl_path)
+                thumb_handle = await client.upload_file(thumb_file.dl_path)
+        media = InputMediaUploadedDocument(
+            file=file_handle,
+            mime_type="application/pdf",
+            attributes=[
+                DocumentAttributeFilename(f"{self.submission_id.to_filename()}.pdf"),
+            ],
+            thumb=thumb_handle,
+            force_file=True,
         )
         return UploadedMedia(self.submission_id, media, settings)
 

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -1017,7 +1017,7 @@ class Sendable(InlineSendable):
                     if container.status == "exited":
                         output = container.logs()
                         container.remove(force=True)
-                        return output
+                        return output.decode("utf-8")
                     await asyncio.sleep(2)
                 # Kill container
                 logger.warning("Docker timed out, killing container.")

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -344,6 +344,7 @@ class DownloadedFile:
 
 
 async def _download_file(url: str) -> DownloadedFile:
+    logger.debug("Downloading file %s", url)
     dl_path = temp_sandbox_path(file_ext(url))
     with time_taken_downloading_image.time():
         session = aiohttp.ClientSession()

--- a/fa_search_bot/sites/sendable.py
+++ b/fa_search_bot/sites/sendable.py
@@ -301,17 +301,31 @@ def file_ext(file_path: str) -> str:
     return file_path.split(".")[-1].lower()
 
 
+def clean_sandbox() -> None:
+    shutil.rmtree(SANDBOX_DIR, ignore_errors=True)
+
+
+def temp_sandbox_path(ext: str = "mp4") -> str:
+    os.makedirs(SANDBOX_DIR, exist_ok=True)
+    return f"{SANDBOX_DIR}/{uuid.uuid4()}.{ext}"
+
+
+def try_delete_sandbox_file(file_path: str) -> None:
+    if os.path.commonpath([SANDBOX_DIR, file_path]) != SANDBOX_DIR:
+        raise ValueError("Can only delete files in sandbox directory")
+    try:
+        os.remove(file_path)
+    except FileNotFoundError:
+        pass
+
+
 @contextmanager
 def temp_sandbox_file(ext: str = "mp4") -> Generator[str, None, None]:
-    os.makedirs(SANDBOX_DIR, exist_ok=True)
-    temp_path = f"{SANDBOX_DIR}/{uuid.uuid4()}.{ext}"
+    temp_path = temp_sandbox_path(ext=ext)
     try:
         yield temp_path
     finally:
-        try:
-            os.remove(temp_path)
-        except FileNotFoundError:
-            pass
+        try_delete_sandbox_file(temp_path)
 
 
 class DownloadError(Exception):

--- a/fa_search_bot/subscriptions/data_fetcher.py
+++ b/fa_search_bot/subscriptions/data_fetcher.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from asyncio import QueueEmpty
 from typing import Optional, TYPE_CHECKING
@@ -89,7 +88,7 @@ class DataFetcher(Runnable):
             sub_id = await self.watcher.wait_pool.get_next_for_data_fetch()
         except QueueEmpty:
             with time_taken_queue_waiting.time():
-                await asyncio.sleep(self.QUEUE_BACKOFF)
+                await self._wait_while_running(self.QUEUE_BACKOFF)
             return
         self.last_sub_id = sub_id
         # Fetch data

--- a/fa_search_bot/subscriptions/data_fetcher.py
+++ b/fa_search_bot/subscriptions/data_fetcher.py
@@ -100,7 +100,7 @@ class DataFetcher(Runnable):
         counter_subs_found.inc()
         # See if any subscriptions match the submission
         with time_taken_checking_matches.time():
-            matching_subscriptions = self.watcher.check_subscriptions(full_result)
+            matching_subscriptions = await self.watcher.check_subscriptions(full_result)
         logger.debug("Submission %s matches %s subscriptions", sub_id, len(matching_subscriptions))
         # If submission doesn't match any subscriptions, drop it
         if not matching_subscriptions:

--- a/fa_search_bot/subscriptions/data_fetcher.py
+++ b/fa_search_bot/subscriptions/data_fetcher.py
@@ -111,6 +111,7 @@ class DataFetcher(Runnable):
         # Publish results
         sub_matches.inc()
         sub_total_matches.inc(len(matching_subscriptions))
+        self.latest_id_gauge.set(sub_id.submission_id)
         with time_taken_publishing.time():
             await self.watcher.wait_pool.set_fetched_data(sub_id, full_result)
 

--- a/fa_search_bot/subscriptions/data_fetcher.py
+++ b/fa_search_bot/subscriptions/data_fetcher.py
@@ -112,7 +112,7 @@ class DataFetcher(Runnable):
         sub_total_matches.inc(len(matching_subscriptions))
         self.latest_id_gauge.set(sub_id.submission_id)
         with time_taken_publishing.time():
-            await self.watcher.wait_pool.set_fetched_data(sub_id, full_result)
+            await self.watcher.wait_pool.set_fetched_data(sub_id, full_result, matching_subscriptions)
 
     async def fetch_data(self, sub_id: SubmissionID) -> Optional[FASubmissionFull]:
         # Keep trying to fetch data, unless it is gone

--- a/fa_search_bot/subscriptions/media_downloader.py
+++ b/fa_search_bot/subscriptions/media_downloader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from asyncio import QueueEmpty
 from typing import Optional, TYPE_CHECKING
@@ -51,7 +50,7 @@ class MediaDownloader(Runnable):
             full_data = await self.watcher.wait_pool.get_next_for_media_download()
         except QueueEmpty:
             with time_taken_waiting.time():
-                await asyncio.sleep(self.QUEUE_BACKOFF)
+                await self._wait_while_running(self.QUEUE_BACKOFF)
             return
         sendable = SendableFASubmission(full_data)
         sub_id = sendable.submission_id

--- a/fa_search_bot/subscriptions/media_downloader.py
+++ b/fa_search_bot/subscriptions/media_downloader.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from asyncio import QueueEmpty
+from typing import Optional, TYPE_CHECKING
+
+from aiohttp import ClientPayloadError, ServerDisconnectedError, ClientOSError
+from prometheus_client import Counter
+
+from fa_search_bot.sites.furaffinity.sendable import SendableFASubmission
+from fa_search_bot.sites.sendable import UploadedMedia, DownloadError, SendSettings, CaptionSettings, DownloadedFile
+from fa_search_bot.sites.submission_id import SubmissionID
+from fa_search_bot.subscriptions.runnable import Runnable, ShutdownError
+from fa_search_bot.subscriptions.utils import time_taken
+from fa_search_bot.subscriptions.fetch_queue import TooManyRefresh
+
+if TYPE_CHECKING:
+    from fa_search_bot.subscriptions.subscription_watcher import SubscriptionWatcher
+
+
+logger = logging.getLogger(__name__)
+
+time_taken_waiting = time_taken.labels(
+    task="waiting for new events in queue", runnable="MediaDownloader", task_type="waiting"
+)
+time_taken_downloading = time_taken.labels(
+    task="downloading media from art site", runnable="MediaDownloader", task_type="active"
+)
+time_taken_publishing = time_taken.labels(
+    task="publishing results to queues", runnable="MediaDownloader", task_type="waiting"
+)
+cache_results = Counter(
+    "fasearchbot_mediadownloader_cache_fetch_count",
+    "Count of how many times the media downloader checked the cache for submission media",
+    labelnames=["result"]
+)
+cache_hits = cache_results.labels(result="hit")
+cache_misses = cache_results.labels(result="miss")
+
+
+class MediaDownloader(Runnable):
+    CONNECTION_BACKOFF = 20
+
+    def __init__(self, watcher: "SubscriptionWatcher") -> None:
+        super().__init__(watcher)
+        self.last_processed: Optional[SubmissionID] = None
+
+    async def do_process(self) -> None:
+        try:
+            full_data = await self.watcher.wait_pool.get_next_for_media_download()
+        except QueueEmpty:
+            with time_taken_waiting.time():
+                await asyncio.sleep(self.QUEUE_BACKOFF)
+            return
+        sendable = SendableFASubmission(full_data)
+        sub_id = sendable.submission_id
+        self.last_processed = sub_id
+        logger.debug("Got %s from queue, downloading media", sub_id)
+        # Check if cache entry exists
+        cache_entry = self.watcher.submission_cache.load_cache(sub_id)
+        if cache_entry:
+            cache_hits.inc()
+            logger.debug("Got cache entry for %s, setting in waitpool", sub_id)
+            with time_taken_publishing.time():
+                await self.watcher.wait_pool.set_cached(sub_id, cache_entry)
+            return
+        cache_misses.inc()
+        # Upload the file
+        logger.debug("Downloading submission media: %s", sub_id)
+        try:
+            with time_taken_downloading.time():
+                dl_file = await self.download_sendable(sendable)
+        except DownloadError as e:
+            if e.exc.status != 404:
+                raise ValueError(
+                    "Download error while downloading media for submission: %s",
+                    sendable.submission_id,
+                ) from e
+            with time_taken_publishing.time():
+                await self.handle_deleted(sendable)
+            return
+        logger.debug("Download complete for %s, publishing to wait pool", sub_id)
+        with time_taken_publishing.time():
+            await self.watcher.wait_pool.set_downloaded(sub_id, dl_file)
+
+    async def handle_deleted(self, sendable: SendableFASubmission) -> None:
+        sub_id = sendable.submission_id
+        logger.debug("Media for %s disappeared before it could be downloaded, throwing back to the fetch queue", sub_id)
+        try:
+            await self.watcher.wait_pool.revert_data_fetch(sub_id)
+        except TooManyRefresh as e:
+            logger.warning(
+                "Sending submission %s without media. Image could not be downloaded after maximum retries: %s",
+                sub_id,
+                e
+            )
+            uploaded_media = UploadedMedia(sub_id, None, SendSettings(CaptionSettings(False, True, True, True), False, False))
+            await self.watcher.wait_pool.set_uploaded(sub_id, uploaded_media)
+
+    async def download_sendable(self, sendable: SendableFASubmission) -> Optional[tuple[DownloadedFile, SendSettings]]:
+        while self.running:
+            try:
+                return await sendable.download()
+            except DownloadError as e:
+                if e.exc.status in [502, 520, 522, 403, 524]:
+                    logger.warning(
+                        "Media download failed with %s error. Trying again in %s",
+                        e.exc.status,
+                        self.CONNECTION_BACKOFF,
+                    )
+                    await self._wait_while_running(self.CONNECTION_BACKOFF)
+                    continue
+                raise e
+            except ClientPayloadError as e:
+                logger.warning(
+                    "Download failed, server response incomplete, trying again in %s",
+                    self.CONNECTION_BACKOFF,
+                    exc_info=e,
+                )
+                await self._wait_while_running(self.CONNECTION_BACKOFF)
+                continue
+            except ServerDisconnectedError as e:
+                logger.warning(
+                    "Disconnected from server while downloading %s, trying again in %s",
+                    sendable.submission_id,
+                    self.CONNECTION_BACKOFF,
+                    exc_info=e
+                )
+                await self._wait_while_running(self.CONNECTION_BACKOFF)
+                continue
+            except ClientOSError as e:
+                logger.warning(
+                    "Client error while downloading %s, trying again in %s",
+                    sendable.submission_id,
+                    self.CONNECTION_BACKOFF,
+                    exc_info=e
+                )
+                await self._wait_while_running(self.CONNECTION_BACKOFF)
+                continue
+            except Exception as e:
+                raise ValueError("Failed to download media for submission: %s", sendable.submission_id) from e
+        raise ShutdownError("Media downloader has shutdown while trying to download media")
+
+    async def revert_last_attempt(self) -> None:
+        if self.last_processed is None:
+            raise ValueError("Cannot revert last attempt, as there was not a previous attempt")
+        # If media failed to download, re-fetch the data, as something may have changed
+        await self.watcher.wait_pool.revert_data_fetch(self.last_processed)

--- a/fa_search_bot/subscriptions/media_downloader.py
+++ b/fa_search_bot/subscriptions/media_downloader.py
@@ -12,7 +12,7 @@ from fa_search_bot.sites.furaffinity.sendable import SendableFASubmission
 from fa_search_bot.sites.sendable import UploadedMedia, DownloadError, SendSettings, CaptionSettings, DownloadedFile
 from fa_search_bot.sites.submission_id import SubmissionID
 from fa_search_bot.subscriptions.runnable import Runnable, ShutdownError
-from fa_search_bot.subscriptions.utils import time_taken
+from fa_search_bot.subscriptions.utils import time_taken, TimeKeeper
 from fa_search_bot.subscriptions.fetch_queue import TooManyRefresh
 
 if TYPE_CHECKING:
@@ -69,8 +69,10 @@ class MediaDownloader(Runnable):
         # Upload the file
         logger.debug("Downloading submission media: %s", sub_id)
         try:
-            with time_taken_downloading.time():
+            download_timer = TimeKeeper(time_taken_downloading)
+            with download_timer.time():
                 dl_file = await self.download_sendable(sendable)
+            logger.debug("Downloaded submission media: %s, duration: %s seconds", sub_id, download_timer.duration)
         except DownloadError as e:
             if e.exc.status != 404:
                 raise ValueError(

--- a/fa_search_bot/subscriptions/media_downloader.py
+++ b/fa_search_bot/subscriptions/media_downloader.py
@@ -85,6 +85,7 @@ class MediaDownloader(Runnable):
         logger.debug("Download complete for %s, publishing to wait pool", sub_id)
         with time_taken_publishing.time():
             await self.watcher.wait_pool.set_downloaded(sub_id, dl_file)
+        self.latest_id_gauge.set(sub_id.submission_id)
 
     async def handle_deleted(self, sendable: SendableFASubmission) -> None:
         sub_id = sendable.submission_id

--- a/fa_search_bot/subscriptions/media_uploader.py
+++ b/fa_search_bot/subscriptions/media_uploader.py
@@ -9,11 +9,11 @@ from aiohttp import ClientPayloadError, ServerDisconnectedError, ClientOSError
 from prometheus_client import Counter
 
 from fa_search_bot.sites.furaffinity.sendable import SendableFASubmission
-from fa_search_bot.sites.sendable import UploadedMedia, DownloadError, SendSettings, CaptionSettings
+from fa_search_bot.sites.sendable import UploadedMedia
 from fa_search_bot.sites.submission_id import SubmissionID
 from fa_search_bot.subscriptions.runnable import Runnable, ShutdownError
 from fa_search_bot.subscriptions.utils import time_taken
-from fa_search_bot.subscriptions.fetch_queue import TooManyRefresh
+from fa_search_bot.subscriptions.wait_pool import SubmissionCheckState
 
 if TYPE_CHECKING:
     from fa_search_bot.subscriptions.subscription_watcher import SubscriptionWatcher
@@ -22,24 +22,24 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 time_taken_waiting = time_taken.labels(
-    task="waiting for new events in queue", runnable="MediaFetcher", task_type="waiting"
+    task="waiting for new events in queue", runnable="MediaUploader", task_type="waiting"
 )
 time_taken_uploading = time_taken.labels(
-    task="uploading media to telegram", runnable="MediaFetcher", task_type="active"
+    task="uploading media to telegram", runnable="MediaUploader", task_type="active"
 )
 time_taken_publishing = time_taken.labels(
-    task="publishing results to queues", runnable="MediaFetcher", task_type="waiting"
+    task="publishing results to queues", runnable="MediaUploader", task_type="waiting"
 )
 cache_results = Counter(
-    "fasearchbot_mediafetcher_cache_fetch_count",
-    "Count of how many times the media fetcher checked the cache for submission media",
+    "fasearchbot_mediauploader_cache_fetch_count",
+    "Count of how many times the media uploader checked the cache for submission media",
     labelnames=["result"]
 )
 cache_hits = cache_results.labels(result="hit")
 cache_misses = cache_results.labels(result="miss")
 
 
-class MediaFetcher(Runnable):
+class MediaUploader(Runnable):
     CONNECTION_BACKOFF = 20
 
     def __init__(self, watcher: "SubscriptionWatcher") -> None:
@@ -48,13 +48,12 @@ class MediaFetcher(Runnable):
 
     async def do_process(self) -> None:
         try:
-            full_data = await self.watcher.wait_pool.get_next_for_media_upload()
+            sub_state = await self.watcher.wait_pool.get_next_for_media_upload()
         except QueueEmpty:
             with time_taken_waiting.time():
                 await asyncio.sleep(self.QUEUE_BACKOFF)
             return
-        sendable = SendableFASubmission(full_data)
-        sub_id = sendable.submission_id
+        sub_id = sub_state.sub_id
         self.last_processed = sub_id
         logger.debug("Got %s from queue, uploading media", sub_id)
         # Check if cache entry exists
@@ -68,39 +67,19 @@ class MediaFetcher(Runnable):
         cache_misses.inc()
         # Upload the file
         logger.debug("Uploading submission media: %s", sub_id)
-        try:
-            with time_taken_uploading.time():
-                uploaded_media = await self.upload_sendable(sendable)
-        except DownloadError as e:
-            if e.exc.status != 404:
-                raise ValueError(
-                    "Download error while uploading media to telegram for submission: %s",
-                    sendable.submission_id,
-                ) from e
-            uploaded_media = await self.handle_deleted(sendable)
-            if not uploaded_media:
-                return
+        with time_taken_uploading.time():
+            uploaded_media = await self.upload_media(sub_state)
+        # Publish result
         logger.debug("Upload complete for %s, publishing to wait pool", sub_id)
         with time_taken_publishing.time():
             await self.watcher.wait_pool.set_uploaded(sub_id, uploaded_media)
 
-    async def handle_deleted(self, sendable: SendableFASubmission) -> Optional[UploadedMedia]:
-        sub_id = sendable.submission_id
-        logger.debug("Media for %s disappeared before it could be uploaded, throwing back to the fetch queue", sub_id)
-        try:
-            await self.watcher.wait_pool.revert_data_fetch(sub_id)
-        except TooManyRefresh as e:
-            logger.warning(
-                "Sending submission %s without media. Image could not be fetched after maximum retries: %s",
-                sub_id,
-                e
-            )
-            return UploadedMedia(sub_id, None, SendSettings(CaptionSettings(False, True, True, True), False, False))
-
-    async def upload_sendable(self, sendable: SendableFASubmission) -> Optional[UploadedMedia]:
+    async def upload_media(self, sub_state: SubmissionCheckState) -> UploadedMedia:
+        sendable = SendableFASubmission(sub_state.full_data)
+        dl_file, send_settings = sub_state.dl_file
         while self.running:
             try:
-                return await sendable.upload(self.watcher.client)
+                return await sendable.upload_only(self.watcher.client, dl_file, send_settings)
             except ConnectionError as e:
                 logger.warning(
                     "Upload failed, telegram has disconnected, trying again in %s",
@@ -117,16 +96,6 @@ class MediaFetcher(Runnable):
                 )
                 await self._wait_while_running(self.CONNECTION_BACKOFF)
                 continue
-            except DownloadError as e:
-                if e.exc.status in [502, 520, 522, 403, 524]:
-                    logger.warning(
-                        "Media download failed with %s error. Trying again in %s",
-                        e.exc.status,
-                        self.CONNECTION_BACKOFF,
-                    )
-                    await self._wait_while_running(self.CONNECTION_BACKOFF)
-                    continue
-                raise e
             except ServerDisconnectedError as e:
                 logger.warning(
                     "Disconnected from server while uploading %s, trying again in %s",
@@ -147,7 +116,7 @@ class MediaFetcher(Runnable):
                 continue
             except Exception as e:
                 raise ValueError("Failed to upload media to telegram for submission: %s", sendable.submission_id) from e
-        raise ShutdownError("Media fetcher has shutdown while trying to upload media")
+        raise ShutdownError("Media uploader has shutdown while trying to upload media")
 
     async def revert_last_attempt(self) -> None:
         if self.last_processed is None:

--- a/fa_search_bot/subscriptions/media_uploader.py
+++ b/fa_search_bot/subscriptions/media_uploader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from asyncio import QueueEmpty
 from typing import Optional, TYPE_CHECKING
@@ -51,7 +50,7 @@ class MediaUploader(Runnable):
             sub_state = await self.watcher.wait_pool.get_next_for_media_upload()
         except QueueEmpty:
             with time_taken_waiting.time():
-                await asyncio.sleep(self.QUEUE_BACKOFF)
+                await self._wait_while_running(self.QUEUE_BACKOFF)
             return
         sub_id = sub_state.sub_id
         self.last_processed = sub_id

--- a/fa_search_bot/subscriptions/media_uploader.py
+++ b/fa_search_bot/subscriptions/media_uploader.py
@@ -9,7 +9,7 @@ from aiohttp import ClientPayloadError, ServerDisconnectedError, ClientOSError
 from prometheus_client import Counter
 
 from fa_search_bot.sites.furaffinity.sendable import SendableFASubmission
-from fa_search_bot.sites.sendable import UploadedMedia
+from fa_search_bot.sites.sendable import UploadedMedia, try_delete_sandbox_file
 from fa_search_bot.sites.submission_id import SubmissionID
 from fa_search_bot.subscriptions.runnable import Runnable, ShutdownError
 from fa_search_bot.subscriptions.utils import time_taken
@@ -79,7 +79,9 @@ class MediaUploader(Runnable):
         dl_file, send_settings = sub_state.dl_file
         while self.running:
             try:
-                return await sendable.upload_only(self.watcher.client, dl_file, send_settings)
+                uploaded_media = await sendable.upload_only(self.watcher.client, dl_file, send_settings)
+                try_delete_sandbox_file(dl_file.dl_path)
+                return uploaded_media
             except ConnectionError as e:
                 logger.warning(
                     "Upload failed, telegram has disconnected, trying again in %s",

--- a/fa_search_bot/subscriptions/media_uploader.py
+++ b/fa_search_bot/subscriptions/media_uploader.py
@@ -12,7 +12,7 @@ from fa_search_bot.sites.furaffinity.sendable import SendableFASubmission
 from fa_search_bot.sites.sendable import UploadedMedia, try_delete_sandbox_file
 from fa_search_bot.sites.submission_id import SubmissionID
 from fa_search_bot.subscriptions.runnable import Runnable, ShutdownError
-from fa_search_bot.subscriptions.utils import time_taken
+from fa_search_bot.subscriptions.utils import time_taken, TimeKeeper
 from fa_search_bot.subscriptions.wait_pool import SubmissionCheckState
 
 if TYPE_CHECKING:
@@ -67,8 +67,10 @@ class MediaUploader(Runnable):
         cache_misses.inc()
         # Upload the file
         logger.debug("Uploading submission media: %s", sub_id)
-        with time_taken_uploading.time():
+        upload_timer = TimeKeeper(time_taken_uploading)
+        with upload_timer.time():
             uploaded_media = await self.upload_media(sub_state)
+        logger.debug("Uploaded submission media: %s, duration: %s seconds", sub_id, upload_timer.duration)
         # Publish result
         logger.debug("Upload complete for %s, publishing to wait pool", sub_id)
         with time_taken_publishing.time():

--- a/fa_search_bot/subscriptions/media_uploader.py
+++ b/fa_search_bot/subscriptions/media_uploader.py
@@ -75,6 +75,7 @@ class MediaUploader(Runnable):
         logger.debug("Upload complete for %s, publishing to wait pool", sub_id)
         with time_taken_publishing.time():
             await self.watcher.wait_pool.set_uploaded(sub_id, uploaded_media)
+        self.latest_id_gauge.set(sub_id.submission_id)
 
     async def upload_media(self, sub_state: SubmissionCheckState) -> UploadedMedia:
         sendable = SendableFASubmission(sub_state.full_data)

--- a/fa_search_bot/subscriptions/runnable.py
+++ b/fa_search_bot/subscriptions/runnable.py
@@ -82,7 +82,7 @@ class Runnable(ABC):
             # Update metrics
             self.update_processed_metrics()
             # Update heartbeat
-            self.update_heartbeat()
+            await self.update_heartbeat()
 
     @abstractmethod
     async def do_process(self) -> None:
@@ -105,10 +105,10 @@ class Runnable(ABC):
         self.runnable_latest_processed.set_to_current_time()
         self.runnable_processed_count.inc()
 
-    def update_heartbeat(self):
+    async def update_heartbeat(self):
         if datetime.datetime.now() > self.heartbeat_expiry:
             with self.time_taken_updating_heartbeat.time():
-                heartbeat.update_heartbeat(f"FASearchBot_task_{self.class_name}")
+                await asyncio.to_thread(lambda: heartbeat.update_heartbeat(f"FASearchBot_task_{self.class_name}"))
             logger.debug("Heartbeat from %s", self.class_name)
             self.heartbeat_expiry = datetime.datetime.now() + datetime.timedelta(seconds=self.SECONDS_PER_HEARTBEAT)
 

--- a/fa_search_bot/subscriptions/runnable.py
+++ b/fa_search_bot/subscriptions/runnable.py
@@ -35,6 +35,11 @@ time_taken_processing = Summary(
     "Amount of time taken (in seconds) running the do_process() method on each task runner",
     labelnames=["runnable"],
 )
+latest_id_processed = Gauge(
+    "fasearchbot_subscriptiontask_latest_fa_id_processed",
+    "ID of the latest FA submission to be processed by each task runner",
+    labelnames=["runnable"],
+)
 
 
 class ShutdownError(RuntimeError):
@@ -60,6 +65,7 @@ class Runnable(ABC):
         self.runnable_latest_processed = latest_processed_time.labels(runnable=self.class_name)
         self.runnable_processed_count = total_processed_count.labels(runnable=self.class_name)
         self.time_taken_processing = time_taken_processing.labels(runnable=self.class_name)
+        self.latest_id_gauge = latest_id_processed.labels(runnable=self.class_name)
 
     async def run(self) -> None:
         # Start the subscription task

--- a/fa_search_bot/subscriptions/runnable.py
+++ b/fa_search_bot/subscriptions/runnable.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import heartbeat
-from prometheus_client import Gauge, Counter
+from prometheus_client import Gauge, Counter, Summary
 
 from fa_search_bot.subscriptions.utils import time_taken
 

--- a/fa_search_bot/subscriptions/runnable.py
+++ b/fa_search_bot/subscriptions/runnable.py
@@ -66,7 +66,7 @@ class Runnable(ABC):
         self.running = True
         while self.running:
             try:
-                with time_taken_processing.time():
+                with self.time_taken_processing.time():
                     await self.do_process()
             except Exception as e:
                 logger.error("Runnable task %s has failed (will restart) with exception:", self.class_name, exc_info=e)

--- a/fa_search_bot/subscriptions/sender.py
+++ b/fa_search_bot/subscriptions/sender.py
@@ -85,6 +85,7 @@ class Sender(Runnable):
         # Update latest ids with the submission we just checked, and save config
         with time_taken_saving_config.time():
             self.watcher.update_latest_id(next_state.sub_id)
+        self.latest_id_gauge.set(next_state.sub_id.submission_id)
 
     async def _send_updates(self, state: SubmissionCheckState) -> None:
         sendable = SendableFASubmission(state.full_data)

--- a/fa_search_bot/subscriptions/sender.py
+++ b/fa_search_bot/subscriptions/sender.py
@@ -110,7 +110,7 @@ class Sender(Runnable):
         # Check subscriptions
         with time_taken_checking_matches.time():
             # Get subscriptions list again, because it might have changed since DataFetcher checked
-            subscriptions = self.watcher.check_subscriptions(state.full_data)
+            subscriptions = await self.watcher.check_subscriptions(state.full_data)
             # Map which subscriptions require this submission at each destination
             destination_map: Dict[int, List[Subscription]] = collections.defaultdict(lambda: [])
             for sub in subscriptions:

--- a/fa_search_bot/subscriptions/sender.py
+++ b/fa_search_bot/subscriptions/sender.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import collections
 import datetime
 import logging
@@ -72,7 +71,7 @@ class Sender(Runnable):
             next_state = await self.watcher.wait_pool.pop_next_ready_to_send()
         if not next_state:
             with time_taken_waiting.time():
-                await asyncio.sleep(self.QUEUE_BACKOFF)
+                await self._wait_while_running(self.QUEUE_BACKOFF)
             return
         self.last_state = next_state
         logger.debug("Got submission ready to send: %s", next_state.sub_id)

--- a/fa_search_bot/subscriptions/sender.py
+++ b/fa_search_bot/subscriptions/sender.py
@@ -109,8 +109,8 @@ class Sender(Runnable):
         sendable = SendableFASubmission(state.full_data)
         # Check subscriptions
         with time_taken_checking_matches.time():
-            # Get subscriptions list again, because it might have changed since DataFetcher checked
-            subscriptions = await self.watcher.check_subscriptions(state.full_data)
+            # Check the previously-matched subscriptions again, in case any have been removed or blocklists have changed
+            subscriptions = await self.watcher.check_subscriptions(state.full_data, state.matching_subscriptions)
             # Map which subscriptions require this submission at each destination
             destination_map: Dict[int, List[Subscription]] = collections.defaultdict(lambda: [])
             for sub in subscriptions:

--- a/fa_search_bot/subscriptions/sub_id_gatherer.py
+++ b/fa_search_bot/subscriptions/sub_id_gatherer.py
@@ -50,6 +50,7 @@ class SubIDGatherer(Runnable):
         self.latest_recorded_id: Optional[int] = None
         if self.watcher.latest_ids:
             self.latest_recorded_id = max(int(x) for x in self.watcher.latest_ids)
+        self.latest_id_gauge.set_function(lambda: self.latest_recorded_id)
 
     async def do_process(self) -> None:
         try:

--- a/fa_search_bot/subscriptions/subscription.py
+++ b/fa_search_bot/subscriptions/subscription.py
@@ -47,10 +47,12 @@ class Subscription:
         self.query = parse_query(query_str)
         self.paused = False
 
-    def matches_result(self, result: FASubmissionFull, blocklist_query: Query) -> bool:
+    def matches_result(self, result: FASubmissionFull, blocklist_query: Optional[Query]) -> bool:
         if self.paused:
             return False
-        full_query = AndQuery([self.query, blocklist_query])
+        full_query = self.query
+        if blocklist_query:
+            full_query = AndQuery([self.query, blocklist_query])
         return full_query.matches_submission(result)
 
     def to_json(self) -> Dict:

--- a/fa_search_bot/subscriptions/subscription.py
+++ b/fa_search_bot/subscriptions/subscription.py
@@ -30,7 +30,7 @@ class DestinationBlocklist:
         return [{"query": query} for query in self.blocklists.keys()]
 
     @classmethod
-    def from_query(cls, destination: int, data: list[dict[str, str]]) -> DestinationBlocklist:
+    def from_json(cls, destination: int, data: list[dict[str, str]]) -> DestinationBlocklist:
         return cls(destination, {entry["query"]: parse_query(entry["query"]) for entry in data})
 
     @classmethod

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -280,8 +280,16 @@ class SubscriptionWatcher:
                 matching_subscriptions.append(subscription)
         return matching_subscriptions
 
-    async def check_subscriptions(self, full_result: FASubmissionFull) -> list[Subscription]:
-        return self._check_subscriptions_static(self.subscriptions, self.blocklists, full_result)
+    async def check_subscriptions(
+            self,
+            full_result: FASubmissionFull,
+            subscriptions: Optional[list[Subscription]] = None,
+    ) -> list[Subscription]:
+        if subscriptions is None:
+            subscriptions = self.subscriptions
+        else:
+            subscriptions = list(set(subscriptions).intersection(self.subscriptions))
+        return self._check_subscriptions_static(subscriptions, self.blocklists, full_result)
         # loop = asyncio.get_running_loop()
         # return await loop.run_in_executor(
         #     self.checker_executor,

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -127,7 +127,7 @@ class SubscriptionWatcher:
         self.blocklist_query_cache: Dict[str, Query] = dict()
 
         # Initialise sharing data structures
-        self.wait_pool = WaitPool()
+        self.wait_pool = WaitPool(self.config.max_ready_for_upload)
 
         # Initialise runners and tasks
         self.sub_id_gatherer: Optional[SubIDGatherer] = None

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -264,7 +264,7 @@ class SubscriptionWatcher:
         else:
             self.blocklists[destination] = {tag}
 
-    def check_subscriptions(self, full_result: FASubmissionFull) -> List[Subscription]:
+    def _check_subscriptions(self, full_result: FASubmissionFull) -> list[Subscription]:
         # Copy subscriptions, to avoid "changed size during iteration" issues
         subscriptions = self.subscriptions.copy()
         # Check which subscriptions match
@@ -277,6 +277,9 @@ class SubscriptionWatcher:
             if subscription.matches_result(full_result, blocklist_query):
                 matching_subscriptions.append(subscription)
         return matching_subscriptions
+
+    async def check_subscriptions(self, full_result: FASubmissionFull) -> list[Subscription]:
+        return await asyncio.to_thread(lambda: self._check_subscriptions(full_result))
 
     def migrate_chat(self, old_chat_id: int, new_chat_id: int) -> None:
         # Migrate blocklist

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -281,14 +281,15 @@ class SubscriptionWatcher:
         return matching_subscriptions
 
     async def check_subscriptions(self, full_result: FASubmissionFull) -> list[Subscription]:
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            self.checker_executor,
-            self._check_subscriptions_static,
-            self.subscriptions,
-            self.blocklists,
-            full_result,
-        )
+        return self._check_subscriptions_static(self.subscriptions, self.blocklists, full_result)
+        # loop = asyncio.get_running_loop()
+        # return await loop.run_in_executor(
+        #     self.checker_executor,
+        #     self._check_subscriptions_static,
+        #     self.subscriptions,
+        #     self.blocklists,
+        #     full_result,
+        # )
 
     def migrate_chat(self, old_chat_id: int, new_chat_id: int) -> None:
         # Migrate blocklist

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -54,6 +54,10 @@ gauge_wait_pool_size = Gauge(
     "fasearchbot_fasubwatcher_wait_pool_size",
     "Total number of submissions in the wait pool",
 )
+gauge_wait_pool_active_size = Gauge(
+    "fasearchbot_fasubwatcher_wait_pool_active_size",
+    "Total number of submissions in the active wait pool",
+)
 gauge_fetch_queue_size = Gauge(
     "fasearchbot_fasubwatcher_fetch_data_queue_size",
     "Total number of submission IDs in the fetch data queue",
@@ -155,6 +159,7 @@ class SubscriptionWatcher:
         )
         gauge_sub_blocks.set_function(lambda: sum(len(blocks) for blocks in self.blocklists.values()))
         gauge_wait_pool_size.set_function(lambda: self.wait_pool.size())
+        gauge_wait_pool_active_size.set_function(lambda: self.wait_pool.size_active())
         gauge_fetch_queue_new_size.set_function(lambda: self.wait_pool.qsize_fetch_new())
         gauge_fetch_queue_refresh_size.set_function(lambda: self.wait_pool.qsize_fetch_refresh())
         gauge_download_queue_size.set_function(lambda: self.wait_pool.qsize_download())

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -61,9 +61,17 @@ gauge_fetch_queue_size = Gauge(
 )
 gauge_fetch_queue_new_size = gauge_fetch_queue_size.labels(sub_queue="new")
 gauge_fetch_queue_refresh_size = gauge_fetch_queue_size.labels(sub_queue="refresh")
+gauge_download_queue_size = Gauge(
+    "fasearchbot_fasubwatcher_download_queue_size",
+    "Total number of submissions which are ready for media download",
+)
 gauge_upload_queue_size = Gauge(
     "fasearchbot_fasubwatcher_upload_queue_size",
-    "Total number of submissions in the upload queue",
+    "Total number of submissions which are ready for media upload",
+)
+gauge_send_queue_size = Gauge(
+    "fasearchbot_fasubwatcher_send_queue_size",
+    "Total number of submissions which are ready to be sent",
 )
 gauge_running_data_fetcher_count = Gauge(
     "fasearchbot_fasubwatcher_running_data_fetcher_count",
@@ -149,7 +157,9 @@ class SubscriptionWatcher:
         gauge_wait_pool_size.set_function(lambda: self.wait_pool.size())
         gauge_fetch_queue_new_size.set_function(lambda: self.wait_pool.qsize_fetch_new())
         gauge_fetch_queue_refresh_size.set_function(lambda: self.wait_pool.qsize_fetch_refresh())
+        gauge_download_queue_size.set_function(lambda: self.wait_pool.qsize_download())
         gauge_upload_queue_size.set_function(lambda: self.wait_pool.qsize_upload())
+        gauge_send_queue_size.set_function(lambda: self.wait_pool.qsize_send())
         gauge_running_data_fetcher_count.set_function(lambda: len([f for f in self.data_fetchers if f.running]))
         gauge_expected_data_fetcher_count.set(self.config.num_data_fetchers)
         gauge_running_media_downloader_count.set_function(lambda: len([f for f in self.media_downloaders if f.running]))

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -361,7 +361,7 @@ class SubscriptionWatcher:
             for subscription in value["subscriptions"]:
                 subscriptions.add(Subscription.from_json_new_format(subscription, dest_id))
             if value["blocks"]:
-                new_watcher.blocklists[dest_id] = DestinationBlocklist(dest_id, value["blocks"])
+                new_watcher.blocklists[dest_id] = DestinationBlocklist.from_json(dest_id, value["blocks"])
         logger.debug(f"Loaded {len(subscriptions)} subscriptions")
         new_watcher.subscriptions = subscriptions
         return new_watcher

--- a/fa_search_bot/subscriptions/utils.py
+++ b/fa_search_bot/subscriptions/utils.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 from prometheus_client import Summary
@@ -11,6 +12,8 @@ time_taken = Summary(
     labelnames=["runnable", "task", "task_type"],
 )
 
+logger = logging.getLogger()
+
 
 def _latest_submission_in_list(submissions: List[FASubmission]) -> Optional[FASubmission]:
     if not submissions:
@@ -19,13 +22,16 @@ def _latest_submission_in_list(submissions: List[FASubmission]) -> Optional[FASu
 
 
 class TimeKeeper:
-    def __init__(self, recorder: Summary) -> None:
+    def __init__(self, recorder: Summary, log_fmt: Optional[str] = None) -> None:
         self.recorder = recorder
+        self.log_fmt = log_fmt
         self.duration = None
 
     def callback(self, duration: float) -> None:
         self.recorder.observe(duration)
         self.duration = duration
+        if self.log_fmt is not None:
+            logger.debug(self.log_fmt, duration)
 
     def time(self) -> Timer:
         return Timer(self.callback)

--- a/fa_search_bot/subscriptions/utils.py
+++ b/fa_search_bot/subscriptions/utils.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from prometheus_client import Summary
+from prometheus_client.context_managers import Timer
 
 from fa_search_bot.sites.furaffinity.fa_submission import FASubmission
 
@@ -17,3 +18,14 @@ def _latest_submission_in_list(submissions: List[FASubmission]) -> Optional[FASu
     return max(submissions, key=lambda sub: int(sub.submission_id))
 
 
+class TimeKeeper:
+    def __init__(self, recorder: Summary) -> None:
+        self.recorder = recorder
+        self.duration = None
+
+    def callback(self, duration: float) -> None:
+        self.recorder.observe(duration)
+        self.duration = duration
+
+    def time(self) -> Timer:
+        return Timer(self.callback)

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -110,7 +110,7 @@ class WaitPool:
             await self.fetch_data_queue.put_refresh(sub_id)
 
     def states_ready_for_media_download(self) -> list[SubmissionCheckState]:
-        return [s for s in self.submission_state.values()[:] if s.is_ready_for_media_download()]
+        return [s for s in self.submission_state.values() if s.is_ready_for_media_download()]
 
     async def get_next_for_media_download(self) -> FASubmissionFull:
         async with self._lock:
@@ -131,7 +131,7 @@ class WaitPool:
             self.submission_state[sub_id].media_downloading = False
 
     def states_ready_for_media_upload(self) -> list[SubmissionCheckState]:
-        return [s for s in self.submission_state.values()[:] if s.is_ready_for_media_upload()]
+        return [s for s in self.submission_state.values() if s.is_ready_for_media_upload()]
 
     async def get_next_for_media_upload(self) -> SubmissionCheckState:
         async with self._lock:
@@ -191,4 +191,4 @@ class WaitPool:
         return self.fetch_data_queue.qsize_refresh()
 
     def qsize_upload(self) -> int:
-        return len([s for s in self.submission_state.values()[:] if s.is_ready_for_media_upload()])
+        return len([s for s in self.submission_state.values() if s.is_ready_for_media_upload()])

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -192,6 +192,8 @@ class WaitPool:
                 return None
             del self.submission_state[next_state.sub_id]
             del self.active_states[next_state.sub_id]
+            self._media_uploading_event.set()
+            self._media_uploading_event.clear()
             return next_state
 
     async def return_populated_state(self, state: SubmissionCheckState) -> None:

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -113,9 +113,7 @@ class WaitPool:
             if sub_id not in self.submission_state:
                 self.submission_state[sub_id] = SubmissionCheckState(sub_id)
             self.submission_state[sub_id].reset()
-            # Remove from active states
-            if sub_id in self.active_states:
-                del self.active_states[sub_id]
+            # Don't remove from active states, that would risk a deadlock
             # Re-queue for data fetch refresh
             await self.fetch_data_queue.put_refresh(sub_id)
 

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -184,6 +184,11 @@ class WaitPool:
                 return None
             next_state = min(submission_states, key=lambda state: state.key())
             if not next_state.is_ready_to_send():
+                if self.size() > self.max_ready_for_upload:
+                    logger.debug(
+                        "Backlog is large, but next submission in wait pool, %s, is unready to send",
+                        next_state.sub_id
+                    )
                 return None
             del self.submission_state[next_state.sub_id]
             del self.active_states[next_state.sub_id]

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -40,13 +40,30 @@ class SubmissionCheckState:
         self.uploaded_media = None
 
     def is_ready_for_media_download(self) -> bool:
-        return self.full_data is not None and not self.media_downloading and not self.is_ready_for_media_upload()
+        return all(
+            [
+                self.full_data is not None,
+                self.dl_file is None,
+                not self.media_downloading,
+            ]
+        )
 
     def is_ready_for_media_upload(self) -> bool:
-        return self.dl_file is not None and not self.media_uploading and not self.is_ready_to_send()
+        return all(
+            [
+                self.dl_file is not None,
+                not self.media_uploading,
+                not self.is_ready_to_send(),
+            ]
+        )
 
     def is_ready_to_send(self) -> bool:
-        return self.uploaded_media is not None or self.cache_entry is not None
+        return any(
+            [
+                self.uploaded_media is not None,
+                self.cache_entry is not None,
+            ]
+        )
 
 
 class WaitPool:

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -110,7 +110,7 @@ class WaitPool:
             await self.fetch_data_queue.put_refresh(sub_id)
 
     def states_ready_for_media_download(self) -> list[SubmissionCheckState]:
-        return [s for s in self.submission_state.values() if s.is_ready_for_media_download()]
+        return [s for s in self.submission_state.values()[:] if s.is_ready_for_media_download()]
 
     async def get_next_for_media_download(self) -> FASubmissionFull:
         async with self._lock:
@@ -131,7 +131,7 @@ class WaitPool:
             self.submission_state[sub_id].media_downloading = False
 
     def states_ready_for_media_upload(self) -> list[SubmissionCheckState]:
-        return [s for s in self.submission_state.values() if s.is_ready_for_media_upload()]
+        return [s for s in self.submission_state.values()[:] if s.is_ready_for_media_upload()]
 
     async def get_next_for_media_upload(self) -> SubmissionCheckState:
         async with self._lock:
@@ -191,4 +191,4 @@ class WaitPool:
         return self.fetch_data_queue.qsize_refresh()
 
     def qsize_upload(self) -> int:
-        return len([s for s in self.submission_state.values() if s.is_ready_for_media_upload()])
+        return len([s for s in self.submission_state.values()[:] if s.is_ready_for_media_upload()])

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict, Union
 from telethon.tl.types import TypeInputPeer
 
 from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull
-from fa_search_bot.sites.sendable import UploadedMedia
+from fa_search_bot.sites.sendable import UploadedMedia, DownloadedFile, SendSettings
 from fa_search_bot.sites.sent_submission import SentSubmission
 from fa_search_bot.sites.submission_id import SubmissionID
 from fa_search_bot.subscriptions.fetch_queue import FetchQueue
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 class SubmissionCheckState:
     sub_id: SubmissionID
     full_data: Optional[FASubmissionFull] = None
+    media_downloading: bool = False
+    dl_file: Optional[tuple[DownloadedFile, SendSettings]] = None
     media_uploading: bool = False
     cache_entry: Optional[SentSubmission] = None
     uploaded_media: Optional[UploadedMedia] = None
@@ -28,8 +30,19 @@ class SubmissionCheckState:
     def key(self) -> int:
         return int(self.sub_id.submission_id)
 
+    def reset(self) -> None:
+        self.full_data = None
+        self.media_downloading = False
+        self.dl_file = None
+        self.media_uploading = False
+        self.cache_entry = None
+        self.uploaded_media = None
+
+    def is_ready_for_media_download(self) -> bool:
+        return self.full_data is not None and not self.media_downloading and not self.is_ready_for_media_upload()
+
     def is_ready_for_media_upload(self) -> bool:
-        return self.full_data is not None and not self.is_ready_to_send()
+        return self.dl_file is not None and not self.media_uploading and not self.is_ready_to_send()
 
     def is_ready_to_send(self) -> bool:
         return self.uploaded_media is not None or self.cache_entry is not None
@@ -59,8 +72,11 @@ class WaitPool:
     async def get_next_for_data_fetch(self) -> SubmissionID:
         return self.fetch_data_queue.get_nowait()
 
+    def count_fetched_not_uploaded(self) -> int:
+        return len(self.states_ready_for_media_download()) + len(self.states_ready_for_media_upload())
+
     async def set_fetched_data(self, sub_id: SubmissionID, full_data: FASubmissionFull) -> None:
-        while len(self.states_ready_for_media_upload()) > self.MAX_READY_FOR_UPLOAD:
+        while self.count_fetched_not_uploaded() > self.MAX_READY_FOR_UPLOAD:
             logger.debug("Waiting for media uploads to get below submission count limit")
             await self._media_uploading_event.wait()
         async with self._lock:
@@ -73,16 +89,34 @@ class WaitPool:
         async with self._lock:
             if sub_id not in self.submission_state:
                 self.submission_state[sub_id] = SubmissionCheckState(sub_id)
-            self.submission_state[sub_id].full_data = None
-            self.submission_state[sub_id].media_uploading = False
-            self.submission_state[sub_id].cache_entry = None
-            self.submission_state[sub_id].uploaded_media = None
+            self.submission_state[sub_id].reset()
             await self.fetch_data_queue.put_refresh(sub_id)
+
+    def states_ready_for_media_download(self) -> list[SubmissionCheckState]:
+        return [s for s in self.submission_state.values() if s.is_ready_for_media_download()]
+
+    async def get_next_for_media_download(self) -> FASubmissionFull:
+        async with self._lock:
+            submission_states = self.states_ready_for_media_download()
+            if not submission_states:
+                raise QueueEmpty()
+            next_state = min(submission_states, key=lambda state: state.key())
+            next_state.media_downloading = True
+            self._media_uploading_event.set()
+            self._media_uploading_event.clear()
+            return next_state.full_data
+
+    async def set_downloaded(self, sub_id: SubmissionID, downloaded: tuple[DownloadedFile, SendSettings]) -> None:
+        async with self._lock:
+            if sub_id not in self.submission_state:
+                return
+            self.submission_state[sub_id].dl_file = downloaded
+            self.submission_state[sub_id].media_downloading = False
 
     def states_ready_for_media_upload(self) -> list[SubmissionCheckState]:
         return [s for s in self.submission_state.values() if s.is_ready_for_media_upload()]
 
-    async def get_next_for_media_upload(self) -> FASubmissionFull:
+    async def get_next_for_media_upload(self) -> SubmissionCheckState:
         async with self._lock:
             submission_states = self.states_ready_for_media_upload()
             if not submission_states:
@@ -91,19 +125,23 @@ class WaitPool:
             next_state.media_uploading = True
             self._media_uploading_event.set()
             self._media_uploading_event.clear()
-            return next_state.full_data
+            if next_state.full_data is None or next_state.dl_file is None:
+                raise ValueError(f"Submission ID {next_state.sub_id} is ready for upload, but lacks data or media")
+            return next_state
 
     async def set_cached(self, sub_id: SubmissionID, cache_entry: SentSubmission) -> None:
         async with self._lock:
             if sub_id not in self.submission_state:
                 return
             self.submission_state[sub_id].cache_entry = cache_entry
+            self.submission_state[sub_id].media_uploading = False
 
     async def set_uploaded(self, sub_id: SubmissionID, uploaded: UploadedMedia) -> None:
         async with self._lock:
             if sub_id not in self.submission_state:
                 return
             self.submission_state[sub_id].uploaded_media = uploaded
+            self.submission_state[sub_id].media_uploading = False
 
     async def remove_state(self, sub_id: SubmissionID) -> None:
         async with self._lock:

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,6 +386,77 @@ files = [
 markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
+name = "cryptg"
+version = "0.5.0.post0"
+description = "Cryptographic utilities for Telegram."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "cryptg-0.5.0.post0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9eb089ab72d52cb900458aac46986b6f41b3b2ddf0ffd4b82a2e88f01eac3b93"},
+    {file = "cryptg-0.5.0.post0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:028c5a8f39f491e374d9d3d73d7d1767097a960437a01dda112bdd37767ca9c0"},
+    {file = "cryptg-0.5.0.post0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e30ee45b6dfdd6cc5293bf74f163449c72887012d881780cf77aa712e5165b3"},
+    {file = "cryptg-0.5.0.post0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7519deefe2df2851d1f4963443de2ba461c8272c98cbcc612a0a157fd2ad4840"},
+    {file = "cryptg-0.5.0.post0-cp310-cp310-win32.whl", hash = "sha256:13b0734217d38eaa41f752570bc0b3689e69180e8e381b872542a24cf7cc6931"},
+    {file = "cryptg-0.5.0.post0-cp310-cp310-win_amd64.whl", hash = "sha256:45997ddb2cba61c3c9eeb96acf2dd9d4546677858754f7562e8db09a0d31edea"},
+    {file = "cryptg-0.5.0.post0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d82293ea2515fe38300824fc075f5d4ec3e0fd3142a9ada1d88dae4f553eefec"},
+    {file = "cryptg-0.5.0.post0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2c066b4a2ee4ed90298d557cac19db9c834bd7e4e8435a1e024393155b850bf"},
+    {file = "cryptg-0.5.0.post0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:209cf9a499e9cdb91580c8a5f9a3b7e475514016352350aea3d0a58656d4c2fe"},
+    {file = "cryptg-0.5.0.post0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6e144749355ee2a3473a2c295f8178b58e8bbf127d45bbc670a30df0e44b27b"},
+    {file = "cryptg-0.5.0.post0-cp311-cp311-win32.whl", hash = "sha256:2ea4ac6a1b8677c41b0df368be7779ed19b07ef033a290d35b0bf2d202a34ca9"},
+    {file = "cryptg-0.5.0.post0-cp311-cp311-win_amd64.whl", hash = "sha256:882f12602db8d1021271a83275fb5b56bd6dbea22a6de086c26f4a22263d6c53"},
+    {file = "cryptg-0.5.0.post0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:39795b25237da4ca6140cf4c2924807bfb683e528823ebbbae45b95f174ec903"},
+    {file = "cryptg-0.5.0.post0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84f6b6f623d894ff88429805b7a1670f43df7dd05a71edc2f3c7b34175182c99"},
+    {file = "cryptg-0.5.0.post0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9107b7daf308b453f00635f0491e4e658034925f19aa8d6623c73fe4e5764178"},
+    {file = "cryptg-0.5.0.post0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96da29d91bab292a7f91c43e27367529b5e9e81c894ceea29055460d0fe86346"},
+    {file = "cryptg-0.5.0.post0-cp312-cp312-win32.whl", hash = "sha256:2ff7f381746f0fcec3b8a25f5d39b9f7c84d7c59d5d27d5c4d53c6b2ba927a98"},
+    {file = "cryptg-0.5.0.post0-cp312-cp312-win_amd64.whl", hash = "sha256:cef8ed1144e11b3fbb85c2bddac45a783fedec7e7a78980b195a9b217087c619"},
+    {file = "cryptg-0.5.0.post0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9dfc86e0a4b200585b0d0a0ab349738f22b8ff9d14621ed7b37a2a415b78c3a5"},
+    {file = "cryptg-0.5.0.post0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9abb52b4d6c275f7148acec5a712c9731280794cd46b4e0fae8c6428f7ba5858"},
+    {file = "cryptg-0.5.0.post0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:852e88327fc0050c47a1973e0ca33ffb7211c3d739965bff923fc202aeda1567"},
+    {file = "cryptg-0.5.0.post0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:feb3dc38d1766470239c76ca2f5003d8233d3a179a342e8731d5c5c6c57c08c9"},
+    {file = "cryptg-0.5.0.post0-cp313-cp313-win32.whl", hash = "sha256:2adfb6ddeb7be5678121e254b7d113e6f25923a8c9c41dff2b7c777eb6b318ff"},
+    {file = "cryptg-0.5.0.post0-cp313-cp313-win_amd64.whl", hash = "sha256:e0666f1d4dc551c1cb86378b7adf4d927a1a79fafd9c25e88bda1de43e6d1f7b"},
+    {file = "cryptg-0.5.0.post0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b576af2135cc8238cd0a9fc1fe80b0b67b39e80ebd94d34235d1fc0da406ee1"},
+    {file = "cryptg-0.5.0.post0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9595969e5e52885be4f0c7498891dbec462e0606924320f5cd229248758f1866"},
+    {file = "cryptg-0.5.0.post0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:896e327143e103ce7690ac140e67492a890b0b4ec0d52d5db1701c5e140b52f1"},
+    {file = "cryptg-0.5.0.post0-cp37-cp37m-win32.whl", hash = "sha256:0c93d1744b9bcc15244bf343a63c8248c78ba920129ecbbe08fb6b17c40b5797"},
+    {file = "cryptg-0.5.0.post0-cp37-cp37m-win_amd64.whl", hash = "sha256:32c37eaeb26a5360735520c03f5a499b43c9d0787f2fb6f34fca7d5ad71789e2"},
+    {file = "cryptg-0.5.0.post0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3872fdf62cb5a977a5d4c2a76c808c7bea3559350f468e902c8da4b67a8375e7"},
+    {file = "cryptg-0.5.0.post0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99481f08c52a5d5f3bc5889d45cf75b9c69ed15c537f369ffe77ca5c365fdab0"},
+    {file = "cryptg-0.5.0.post0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb525eb3e2af680c66e82a73256e54f50c7fd5dd648555e350451a3661c8944d"},
+    {file = "cryptg-0.5.0.post0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1278f2e6a9f349d9a6bbdfd900dd0784a07bc182f05de694628bec18077b922d"},
+    {file = "cryptg-0.5.0.post0-cp38-cp38-win32.whl", hash = "sha256:cad91aafaa06468237eeb03004ff4b0664e4f69cfb473f6159707c23b08198c4"},
+    {file = "cryptg-0.5.0.post0-cp38-cp38-win_amd64.whl", hash = "sha256:b6dd75e7ec26fdc9747ad6d4ca1aba6ad366b8c246976714e499a58d8e52f03a"},
+    {file = "cryptg-0.5.0.post0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d9965ecb7e981bd3a5c4f7ead90007acae21622f73f9cc71df8fdb43f9fce5a4"},
+    {file = "cryptg-0.5.0.post0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f61d0bf0ce197c6d96e8abe9e810de206bf010e41b645d4b06bd416108de47"},
+    {file = "cryptg-0.5.0.post0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b589c0e3d45ff3fcfd357d31be05669aa5735c912e4f93d26b34dd6e86f878a3"},
+    {file = "cryptg-0.5.0.post0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb72af3ba1b8e9f39c8990a32c355b9fd7f26ee6b377303bba240f857ff6478d"},
+    {file = "cryptg-0.5.0.post0-cp39-cp39-win32.whl", hash = "sha256:1baeff7a8a208998d4f8512833586199058310e058f301834ceec621cbf4618a"},
+    {file = "cryptg-0.5.0.post0-cp39-cp39-win_amd64.whl", hash = "sha256:5d3505c47b1e65775802b28f103b352ef9f6140d3e1004bb8afa5c2a09675f3e"},
+    {file = "cryptg-0.5.0.post0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5451cf4a0ec7535a3cef10789b8e40ccd17dff90afd65627df56307dd00a1bf1"},
+    {file = "cryptg-0.5.0.post0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6795041b09f68e11050921599be33868b0d9ebb47cb84443392dd847516659f3"},
+    {file = "cryptg-0.5.0.post0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1105e5035a28eba4878ff937032b873af66606c0a5bf2deadee0216f0aef067d"},
+    {file = "cryptg-0.5.0.post0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd3b8b790dca04ad9cc755383cd563f032027271d9bd763f9486ec527daa909e"},
+    {file = "cryptg-0.5.0.post0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cb7d27457634179fa3c1f8b20d70a81b6fa05e21e695c7c65b3c6dbaf72a247c"},
+    {file = "cryptg-0.5.0.post0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37317f617dc4c1e0b0b042712948b2c817703e8e9334da3a9e5f24c31fbfc32"},
+    {file = "cryptg-0.5.0.post0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7284e58ad588413e50bc66e29f6441734af5cdbf21504ee3ba2dea079b9fbc86"},
+    {file = "cryptg-0.5.0.post0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ec43094134043a594e1e19036749608c788c3b21bbf5a56f76a723ea2facc865"},
+    {file = "cryptg-0.5.0.post0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:cb8eb05d872291db96317c332adfe86350c0ce06c1ca6704133bdcef95e383fd"},
+    {file = "cryptg-0.5.0.post0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:caec1871de5798f504a62bfb004f2060e60ea4edad636a298f176335e0976ffc"},
+    {file = "cryptg-0.5.0.post0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:277985cefe02e0bd027316ee2daacff29387af6b930c44bd1e1ffba37ddc1c8d"},
+    {file = "cryptg-0.5.0.post0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d53a9fea1c6331418a60b9a93db3d6dac5e54fa10f1d4b8f8b77107c58bbaaa"},
+    {file = "cryptg-0.5.0.post0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecf7b9be44d9edb50e3ae5a4afb3caa952c707c62b327772abacfacf72b50c76"},
+    {file = "cryptg-0.5.0.post0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:fc270c303989ddfbb961bac0aa84a98eb57de2e1462089a003ad14f375d1b72d"},
+    {file = "cryptg-0.5.0.post0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f417cd83bc39b62c0183bfd87d1f47487eb0380dfecc4227aa0f262710e28ecc"},
+    {file = "cryptg-0.5.0.post0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70a751732f55e611106561c8db74c0de77e22bfe5d7f7b902bb0f0bf783a42e7"},
+    {file = "cryptg-0.5.0.post0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9ebd0e32d67d835b306d076e39b68b05dc178d7723a35397550af24eb87d280"},
+    {file = "cryptg-0.5.0.post0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ec12886a4131aab2b23b434cbec5e8ad88faf8824421f4070b808e2123a1c102"},
+    {file = "cryptg-0.5.0.post0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0b4a03a838843d7980bd3a476d3e594883f41ab510da65f34e0d37b35025199c"},
+    {file = "cryptg-0.5.0.post0.tar.gz", hash = "sha256:be5b36e662a73c9b2f1e02e4f0d71b0f97870e514e924d5988d7253a780e3a7b"},
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 description = "A Python library for the Docker Engine API."
@@ -2076,4 +2147,4 @@ sphinxcontrib-napoleon = {version = ">=0.7,<0.8", extras = ["docs"]}
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "cd349e995036f091e281aee3789de0932ce5e2b0ea2f626fcc257af562e7b979"
+content-hash = "0e96eb2ab5f2274f2ac411df3c24a3d6157f06909cf382baedb114709ce5a0f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ Pillow = "^11.2.1"
 yippi = "0.2.0.1"
 prometheus-client = "^0.11.0"
 click = "^8.2.1"
+cryptg = "^0.5.0.post0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.0"

--- a/run.py
+++ b/run.py
@@ -8,7 +8,8 @@ import click
 from prometheus_client import Counter
 
 from fa_search_bot.bot import FASearchBot
-from fa_search_bot.config import Config
+from fa_search_bot.config import Config, DEFAULT_MAX_READY_FOR_UPLOAD, DEFAULT_NUM_DATA_FETCHERS, \
+    DEFAULT_NUM_MEDIA_DOWNLOADERS, DEFAULT_NUM_MEDIA_UPLOADERS
 
 log_entries = Counter(
     "fasearchbot_log_messages_total",
@@ -44,15 +45,17 @@ def setup_logging(log_level: str = "INFO") -> None:
 @click.command()
 @click.option("--log-level", type=str, help="Log level for the logger", default="INFO")
 @click.option("--no-subscriptions", type=bool, default=False, help="Disable subscription watcher")
-@click.option("--sub-watcher-data-fetchers", type=int, default=2, help="Number of DataFetcher tasks which should spin up in the subscription watcher")
-@click.option("--sub-watcher-media-downloaders", type=int, default=2, help="Number of MediaDownloader tasks which should spin up in the subscription watcher")
-@click.option("--sub-watcher-media-uploaders", type=int, default=1, help="Number of MediaUploader tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-data-fetchers", type=int, default=DEFAULT_NUM_DATA_FETCHERS, help="Number of DataFetcher tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-media-downloaders", type=int, default=DEFAULT_NUM_MEDIA_DOWNLOADERS, help="Number of MediaDownloader tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-media-uploaders", type=int, default=DEFAULT_NUM_MEDIA_UPLOADERS, help="Number of MediaUploader tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-max-ready-for-upload", type=int, default=DEFAULT_MAX_READY_FOR_UPLOAD, help="Maximum number of submissions which should have data and media fetched before being uploaded to Telegram, to prevent data being too stale by the time it comes to upload, especially if catching up on backlog")
 def main(
         log_level: str,
         no_subscriptions: bool,
         sub_watcher_data_fetchers: int,
         sub_watcher_media_downloaders: int,
         sub_watcher_media_uploaders: int,
+        sub_watcher_max_ready_for_upload: int,
 ) -> None:
     setup_logging(log_level)
     # Construct config and ingest flags
@@ -61,6 +64,7 @@ def main(
     config.subscription_watcher.num_data_fetchers = sub_watcher_data_fetchers
     config.subscription_watcher.num_media_downloaders = sub_watcher_media_downloaders
     config.subscription_watcher.num_media_uploaders = sub_watcher_media_uploaders
+    config.subscription_watcher.max_ready_for_upload = sub_watcher_max_ready_for_upload
     # Create and start the bot
     bot = FASearchBot(config)
     loop = asyncio.get_event_loop()

--- a/run.py
+++ b/run.py
@@ -46,7 +46,7 @@ def setup_logging(log_level: str = "INFO") -> None:
 @click.option("--no-subscriptions", type=bool, default=False, help="Disable subscription watcher")
 @click.option("--sub-watcher-data-fetchers", type=int, default=2, help="Number of DataFetcher tasks which should spin up in the subscription watcher")
 @click.option("--sub-watcher-media-downloaders", type=int, default=2, help="Number of MediaDownloader tasks which should spin up in the subscription watcher")
-@click.option("--sub-watcher-media-uploaders", type=int, default=2, help="Number of MediaUploader tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-media-uploaders", type=int, default=1, help="Number of MediaUploader tasks which should spin up in the subscription watcher")
 def main(
         log_level: str,
         no_subscriptions: bool,

--- a/run.py
+++ b/run.py
@@ -45,19 +45,22 @@ def setup_logging(log_level: str = "INFO") -> None:
 @click.option("--log-level", type=str, help="Log level for the logger", default="INFO")
 @click.option("--no-subscriptions", type=bool, default=False, help="Disable subscription watcher")
 @click.option("--sub-watcher-data-fetchers", type=int, default=2, help="Number of DataFetcher tasks which should spin up in the subscription watcher")
-@click.option("--sub-watcher-media-fetchers", type=int, default=2, help="Number of MediaFetcher tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-media-downloaders", type=int, default=2, help="Number of MediaDownloader tasks which should spin up in the subscription watcher")
+@click.option("--sub-watcher-media-uploaders", type=int, default=2, help="Number of MediaUploader tasks which should spin up in the subscription watcher")
 def main(
         log_level: str,
         no_subscriptions: bool,
         sub_watcher_data_fetchers: int,
-        sub_watcher_media_fetchers: int,
+        sub_watcher_media_downloaders: int,
+        sub_watcher_media_uploaders: int,
 ) -> None:
     setup_logging(log_level)
     # Construct config and ingest flags
     config = Config.load_from_file(os.getenv('CONFIG_FILE', 'config.json'))
     config.subscription_watcher.enabled = not no_subscriptions
     config.subscription_watcher.num_data_fetchers = sub_watcher_data_fetchers
-    config.subscription_watcher.num_media_fetchers = sub_watcher_media_fetchers
+    config.subscription_watcher.num_media_downloaders = sub_watcher_media_downloaders
+    config.subscription_watcher.num_media_uploaders = sub_watcher_media_uploaders
     # Create and start the bot
     bot = FASearchBot(config)
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
Instead of having 1 task runner in the subscription watcher pipeline which downloads media from FA and uploads it to Telegram, this splits that into 2 runners, one of which downloads from FA and one uploads to Telegram. This provides greater parallelisation, because one can scale without the other.

It has a downside, that files can be left in the sandbox directory, whoops. But it seems like that is not too big of an issue. Some auto-cleanup on startup can be added if needed.

This meant splitting the Sendable.upload() method into Sendable.download() and Sendable.upload_only(), but the old upload() method remains a combined entrypoint to both.
The only file type significantly affected by this is PDF. Previously these were sent as URLs to Telegram, for Telegram to download from FA. Now we download them ourselves. Shouldn't make much difference, shouldn't be a major performance drop

This also does a few unrelated things:
- This also adds click, adding command line flag support for configuring the logger and the subscription watcher tuning.
- Also, refactoring how blocklists are held by the SubscriptionWatcher, to create some distinct objects for managing them, providing a more clear parser-caching mechanism
- Also adding some prometheus metrics for how long it takes to read and write the cache
- Switching out DataFetcher and other subscription task runners from using repeated `asyncio.sleep()` loops to waiting on actual signals from things. This should speed up shutdown
- Added some generic prometheus metrics for subscription task runners (like how long 'do_process()' took overall)
- Additional logging of timing of events like downloading and uploading files, sending messages, etc
- More metrics around sending attempts and times
- Bigger backoff on SubIDGatherer if the backlog is already large
- More metrics around waitpool sizes
- Added cryptg dependency to speed up Telegram file sending