### PR TITLE
Create generic QueryTarget submission data class, for checking subscriptions against

### DIFF
--- a/experiments/whoosh_example.py
+++ b/experiments/whoosh_example.py
@@ -9,7 +9,8 @@ from whoosh.searching import Searcher
 
 from fa_search_bot.subscriptions.query_parser import Query, OrQuery, AndQuery, RatingQuery, WordQuery, PrefixQuery, RegexQuery, \
     PhraseQuery, TitleField, DescriptionField, KeywordField
-from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, Rating, FAUser
+from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FAUser
+from fa_search_bot.sites.submission import Rating
 from fa_search_bot.subscriptions.subscription_watcher import rating_dict
 from fa_search_bot.subscriptions.subscription import Subscription
 

--- a/fa_search_bot/sites/furaffinity/fa_submission.py
+++ b/fa_search_bot/sites/furaffinity/fa_submission.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import logging
 import re
 from abc import ABC
-from enum import Enum
 from typing import TYPE_CHECKING, TypedDict, Dict
 
 import aiohttp
 import dateutil.parser
 from telethon import Button
+
+from fa_search_bot.sites.submission import Rating, QueryTarget
 
 if TYPE_CHECKING:
     import datetime
@@ -19,13 +20,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-class Rating(Enum):
-    GENERAL = 1
-    MATURE = 2
-    ADULT = 3
-
 
 UserShortResp = TypedDict(
     "UserShortResp",
@@ -249,6 +243,15 @@ class FASubmissionFull(FASubmissionShort):
     @property
     def download_file_ext(self) -> str:
         return self.download_url.split(".")[-1].lower()
+
+    def to_query_target(self) -> QueryTarget:
+        return QueryTarget(
+            title=[self.title],
+            keywords=self.keywords,
+            description=[self.description],
+            artist=[self.author.name, self.author.profile_name],
+            rating=self.rating,
+        )
 
 
 class FAStatus:

--- a/fa_search_bot/sites/submission.py
+++ b/fa_search_bot/sites/submission.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import dataclasses
+from enum import Enum
+
+
+class Rating(Enum):
+    GENERAL = 1
+    MATURE = 2
+    ADULT = 3
+
+
+@dataclasses.dataclass
+class QueryTarget:
+    title: list[str]
+    keywords: list[str]
+    description: list[str]
+    artist: list[str]
+    rating: Rating

--- a/fa_search_bot/subscriptions/data_fetcher.py
+++ b/fa_search_bot/subscriptions/data_fetcher.py
@@ -100,7 +100,7 @@ class DataFetcher(Runnable):
         counter_subs_found.inc()
         # See if any subscriptions match the submission
         with time_taken_checking_matches.time():
-            matching_subscriptions = await self.watcher.check_subscriptions(full_result)
+            matching_subscriptions = await self.watcher.check_subscriptions(full_result.to_query_target())
         logger.debug("Submission %s matches %s subscriptions", sub_id, len(matching_subscriptions))
         # If submission doesn't match any subscriptions, drop it
         if not matching_subscriptions:

--- a/fa_search_bot/subscriptions/query_parser.py
+++ b/fa_search_bot/subscriptions/query_parser.py
@@ -20,14 +20,12 @@ from pyparsing import (
     printables,
 )
 
-from fa_search_bot.sites.furaffinity.fa_submission import Rating
+from fa_search_bot.sites.submission import Rating, QueryTarget
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Pattern, Sequence
+    from typing import Any, Optional, Pattern, Sequence
 
     from pyparsing import ParserElement, ParseResults
-
-    from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull
 
 
 logger = logging.getLogger(__name__)
@@ -48,15 +46,15 @@ boundary_pattern_start = r"(?:^|(?<=[\s" + re.escape(punctuation) + "]))"
 boundary_pattern_end = r"(?:(?=[\s" + re.escape(punctuation) + "])|$)"
 
 
-def _split_text_to_words(text: str) -> List[str]:
+def _split_text_to_words(text: str) -> list[str]:
     return re.split(punctuation_pattern, text)
 
 
-def _clean_word_list(words: List[str]) -> List[str]:
+def _clean_word_list(words: list[str]) -> list[str]:
     return [x.lower().strip(punctuation) for x in words]
 
 
-def _split_text_to_cleaned_words(text: str) -> List[str]:
+def _split_text_to_cleaned_words(text: str) -> list[str]:
     return _clean_word_list(_split_text_to_words(text))
 
 
@@ -65,15 +63,15 @@ FieldLocation = NewType("FieldLocation", str)
 
 class Field(ABC):
     @abstractmethod
-    def get_field_words(self, sub: FASubmissionFull) -> List[str]:
+    def get_field_words(self, sub: QueryTarget) -> list[str]:
         raise NotImplementedError
 
     @abstractmethod
-    def get_texts(self, sub: FASubmissionFull) -> List[str]:
+    def get_texts(self, sub: QueryTarget) -> list[str]:
         raise NotImplementedError
 
     @abstractmethod
-    def get_texts_dict(self, sub: FASubmissionFull) -> Dict[FieldLocation, str]:
+    def get_texts_dict(self, sub: QueryTarget) -> dict[FieldLocation, str]:
         raise NotImplementedError
 
     def __eq__(self, other: Any) -> bool:
@@ -84,54 +82,51 @@ class Field(ABC):
 
 
 class KeywordField(Field):
-    def get_field_words(self, sub: FASubmissionFull) -> List[str]:
+    def get_field_words(self, sub: QueryTarget) -> list[str]:
         return _clean_word_list(sub.keywords)
 
-    def get_texts(self, sub: FASubmissionFull) -> List[str]:
+    def get_texts(self, sub: QueryTarget) -> list[str]:
         return sub.keywords
 
-    def get_texts_dict(self, sub: FASubmissionFull) -> Dict[FieldLocation, str]:
+    def get_texts_dict(self, sub: QueryTarget) -> dict[FieldLocation, str]:
         return {FieldLocation(f"keyword_{num}"): keyword for num, keyword in enumerate(sub.keywords)}
 
 
 class TitleField(Field):
-    def get_field_words(self, sub: FASubmissionFull) -> List[str]:
-        return _split_text_to_cleaned_words(sub.title)
+    def get_field_words(self, sub: QueryTarget) -> list[str]:
+        return sum([_split_text_to_cleaned_words(title) for title in sub.title], start=[])
 
-    def get_texts(self, sub: FASubmissionFull) -> List[str]:
-        return [sub.title]
+    def get_texts(self, sub: QueryTarget) -> list[str]:
+        return sub.title
 
-    def get_texts_dict(self, sub: FASubmissionFull) -> Dict[FieldLocation, str]:
-        return {FieldLocation("title"): sub.title}
+    def get_texts_dict(self, sub: QueryTarget) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"title_{num}"): title for num, title in enumerate(sub.title)}
 
 
 class DescriptionField(Field):
-    def get_field_words(self, sub: FASubmissionFull) -> List[str]:
-        return _split_text_to_cleaned_words(sub.description)
+    def get_field_words(self, sub: QueryTarget) -> list[str]:
+        return sum([_split_text_to_cleaned_words(desc) for desc in sub.description], start=[])
 
-    def get_texts(self, sub: FASubmissionFull) -> List[str]:
-        return [sub.description]
+    def get_texts(self, sub: QueryTarget) -> list[str]:
+        return sub.description
 
-    def get_texts_dict(self, sub: FASubmissionFull) -> Dict[FieldLocation, str]:
-        return {FieldLocation("description"): sub.description}
+    def get_texts_dict(self, sub: QueryTarget) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"description_{num}"): desc for num, desc in enumerate(sub.description)}
 
 
 class ArtistField(Field):
-    def get_field_words(self, sub: FASubmissionFull) -> List[str]:
-        return [sub.author.name.lower(), sub.author.profile_name.lower()]
+    def get_field_words(self, sub: QueryTarget) -> list[str]:
+        return [artist.lower() for artist in sub.artist]
 
-    def get_texts(self, sub: FASubmissionFull) -> List[str]:
-        return [sub.author.name, sub.author.profile_name]
+    def get_texts(self, sub: QueryTarget) -> list[str]:
+        return sub.artist
 
-    def get_texts_dict(self, sub: FASubmissionFull) -> Dict[FieldLocation, str]:
-        return {
-            FieldLocation("name"): sub.author.name,
-            FieldLocation("profile_name"): sub.author.profile_name,
-        }
+    def get_texts_dict(self, sub: QueryTarget) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"artist_{num}"): artist for num, artist in enumerate(sub.artist)}
 
 
 class AnyField(Field):
-    def get_field_words(self, sub: FASubmissionFull) -> List[str]:
+    def get_field_words(self, sub: QueryTarget) -> list[str]:
         return [
             *TitleField().get_field_words(sub),
             *DescriptionField().get_field_words(sub),
@@ -139,7 +134,7 @@ class AnyField(Field):
             *ArtistField().get_field_words(sub),
         ]
 
-    def get_texts(self, sub: FASubmissionFull) -> List[str]:
+    def get_texts(self, sub: QueryTarget) -> list[str]:
         return [
             *TitleField().get_texts(sub),
             *DescriptionField().get_texts(sub),
@@ -147,7 +142,7 @@ class AnyField(Field):
             *ArtistField().get_texts(sub),
         ]
 
-    def get_texts_dict(self, sub: FASubmissionFull) -> Dict[FieldLocation, str]:
+    def get_texts_dict(self, sub: QueryTarget) -> dict[FieldLocation, str]:
         return {
             **TitleField().get_texts_dict(sub),
             **DescriptionField().get_texts_dict(sub),
@@ -170,7 +165,7 @@ class MatchLocation:
         else:
             return location.end_position > self.start_position
 
-    def overlaps_any(self, locations: List["MatchLocation"]) -> bool:
+    def overlaps_any(self, locations: list["MatchLocation"]) -> bool:
         return any(self.overlaps(location) for location in locations)
 
     def __eq__(self, other: Any) -> bool:
@@ -190,13 +185,13 @@ class MatchLocation:
 
 class Query(ABC):
     @abstractmethod
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         raise NotImplementedError
 
 
 class LocationQuery(Query, ABC):
     @abstractmethod
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         raise NotImplementedError
 
 
@@ -204,7 +199,7 @@ class OrQuery(Query):
     def __init__(self, sub_queries: Sequence["Query"]):
         self.sub_queries = sub_queries
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return any(q.matches_submission(sub) for q in self.sub_queries)
 
     def __eq__(self, other: Any) -> bool:
@@ -222,20 +217,20 @@ class OrQuery(Query):
 
 
 class LocationOrQuery(OrQuery, LocationQuery):
-    def __init__(self, sub_queries: List["LocationQuery"]):
+    def __init__(self, sub_queries: list["LocationQuery"]):
         super().__init__(sub_queries)
         # Set it again, so we know sub_queries are LocationQuery objects, rather than just Query objects
-        self.sub_queries: List["LocationQuery"] = sub_queries
+        self.sub_queries: list["LocationQuery"] = sub_queries
 
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         return list(set(match for q in self.sub_queries for match in q.match_locations(sub)))
 
 
 class AndQuery(Query):
-    def __init__(self, sub_queries: List["Query"]):
+    def __init__(self, sub_queries: list["Query"]):
         self.sub_queries = sub_queries
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return all(q.matches_submission(sub) for q in self.sub_queries)
 
     def __eq__(self, other: Any) -> bool:
@@ -256,7 +251,7 @@ class NotQuery(Query):
     def __init__(self, sub_query: "Query"):
         self.sub_query = sub_query
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return not self.sub_query.matches_submission(sub)
 
     def __eq__(self, other: Any) -> bool:
@@ -273,7 +268,7 @@ class RatingQuery(Query):
     def __init__(self, rating: Rating):
         self.rating = rating
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return sub.rating == self.rating
 
     def __eq__(self, other: Any) -> bool:
@@ -293,10 +288,10 @@ class WordQuery(LocationQuery):
             field = AnyField()
         self.field = field
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return self.word.lower() in self.field.get_field_words(sub)
 
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         regex = re.compile(boundary_pattern_start + re.escape(self.word) + boundary_pattern_end, re.I)
         return [
             MatchLocation(location, m.start(), m.end())
@@ -325,13 +320,13 @@ class PrefixQuery(LocationQuery):
             field = AnyField()
         self.field = field
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return any(
             word.startswith(self.prefix.lower()) and word != self.prefix.lower()
             for word in self.field.get_field_words(sub)
         )
 
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         regex = re.compile(
             boundary_pattern_start + re.escape(self.prefix) + not_punctuation_pattern + boundary_pattern_end,
             re.I,
@@ -363,13 +358,13 @@ class SuffixQuery(LocationQuery):
             field = AnyField()
         self.field = field
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return any(
             word.endswith(self.suffix.lower()) and word != self.suffix.lower()
             for word in self.field.get_field_words(sub)
         )
 
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         regex = re.compile(
             boundary_pattern_start + not_punctuation_pattern + re.escape(self.suffix) + boundary_pattern_end,
             re.I,
@@ -401,10 +396,10 @@ class RegexQuery(LocationQuery):
             field = AnyField()
         self.field = field
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return any(self.pattern.search(word) for word in self.field.get_field_words(sub))
 
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         return [
             MatchLocation(location, m.start(), m.end())
             for location, text in self.field.get_texts_dict(sub).items()
@@ -445,10 +440,10 @@ class PhraseQuery(LocationQuery):
             field = AnyField()
         self.field = field
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         return any(self.phrase_regex.search(text) for text in self.field.get_texts(sub))
 
-    def match_locations(self, sub: FASubmissionFull) -> List[MatchLocation]:
+    def match_locations(self, sub: QueryTarget) -> list[MatchLocation]:
         return [
             MatchLocation(location, m.start(), m.end())
             for location, text in self.field.get_texts_dict(sub).items()
@@ -474,7 +469,7 @@ class ExceptionQuery(Query):
         self.word = word
         self.exception = exception
 
-    def matches_submission(self, sub: FASubmissionFull) -> bool:
+    def matches_submission(self, sub: QueryTarget) -> bool:
         word_locations = self.word.match_locations(sub)
         exception_locations = self.exception.match_locations(sub)
         return any(not location.overlaps_any(exception_locations) for location in word_locations)

--- a/fa_search_bot/subscriptions/sender.py
+++ b/fa_search_bot/subscriptions/sender.py
@@ -110,7 +110,10 @@ class Sender(Runnable):
         # Check subscriptions
         with time_taken_checking_matches.time():
             # Check the previously-matched subscriptions again, in case any have been removed or blocklists have changed
-            subscriptions = await self.watcher.check_subscriptions(state.full_data, state.matching_subscriptions)
+            subscriptions = await self.watcher.check_subscriptions(
+                state.full_data.to_query_target(),
+                state.matching_subscriptions,
+            )
             # Map which subscriptions require this submission at each destination
             destination_map: Dict[int, List[Subscription]] = collections.defaultdict(lambda: [])
             for sub in subscriptions:

--- a/fa_search_bot/subscriptions/subscription.py
+++ b/fa_search_bot/subscriptions/subscription.py
@@ -5,8 +5,8 @@ from typing import Optional, Dict, Any
 
 import dateutil.parser
 
+from fa_search_bot.sites.submission import QueryTarget
 from fa_search_bot.subscriptions.query_parser import parse_query, Query, AndQuery, NotQuery
-from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull
 
 
 class DestinationBlocklist:
@@ -47,7 +47,7 @@ class Subscription:
         self.query = parse_query(query_str)
         self.paused = False
 
-    def matches_result(self, result: FASubmissionFull, blocklist_query: Optional[Query]) -> bool:
+    def matches_result(self, result: QueryTarget, blocklist_query: Optional[Query]) -> bool:
         if self.paused:
             return False
         full_query = self.query

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from prometheus_client import Gauge
 
 from fa_search_bot.config import SubscriptionWatcherConfig
+from fa_search_bot.sites.submission import QueryTarget
 from fa_search_bot.subscriptions.media_downloader import MediaDownloader
 from fa_search_bot.subscriptions.media_uploader import MediaUploader
 from fa_search_bot.subscriptions.runnable import ShutdownError
@@ -30,7 +31,6 @@ if TYPE_CHECKING:
     from telethon import TelegramClient
 
     from fa_search_bot.sites.furaffinity.fa_export_api import FAExportAPI
-    from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull
     from fa_search_bot.submission_cache import SubmissionCache
 
 logger = logging.getLogger(__name__)
@@ -331,7 +331,7 @@ class SubscriptionWatcher:
     def _check_subscriptions_static(
             subscriptions: set[Subscription],
             blocklists: dict[int, DestinationBlocklist],
-            full_result: FASubmissionFull,
+            full_result: QueryTarget,
     ) -> list[Subscription]:
         # Copy subscriptions, to avoid "changed size during iteration" issues
         subscriptions = subscriptions.copy()
@@ -348,21 +348,21 @@ class SubscriptionWatcher:
 
     async def check_subscriptions(
             self,
-            full_result: FASubmissionFull,
+            query_target: QueryTarget,
             subscriptions: Optional[list[Subscription]] = None,
     ) -> list[Subscription]:
         if subscriptions is None:
             subscriptions = self.subscriptions
         else:
             subscriptions = list(set(subscriptions).intersection(self.subscriptions))
-        return self._check_subscriptions_static(subscriptions, self.blocklists, full_result)
+        return self._check_subscriptions_static(subscriptions, self.blocklists, query_target)
         # loop = asyncio.get_running_loop()
         # return await loop.run_in_executor(
         #     self.checker_executor,
         #     self._check_subscriptions_static,
         #     self.subscriptions,
         #     self.blocklists,
-        #     full_result,
+        #     query_target,
         # )
 
     def migrate_chat(self, old_chat_id: int, new_chat_id: int) -> None:

--- a/fa_search_bot/tests/sites/test_fa_submission_full.py
+++ b/fa_search_bot/tests/sites/test_fa_submission_full.py
@@ -2,7 +2,8 @@ import datetime
 
 import pytest
 
-from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FAUser, Rating
+from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FAUser
+from fa_search_bot.sites.submission import Rating
 from fa_search_bot.tests.util.submission_builder import SubmissionBuilder
 
 

--- a/fa_search_bot/tests/subscriptions/test_query_parser.py
+++ b/fa_search_bot/tests/subscriptions/test_query_parser.py
@@ -19,7 +19,7 @@ from fa_search_bot.subscriptions.query_parser import (
     WordQuery,
     parse_query,
 )
-from fa_search_bot.sites.furaffinity.fa_submission import Rating
+from fa_search_bot.sites.submission import Rating
 
 
 def test_parser():

--- a/fa_search_bot/tests/subscriptions/test_query_parser__queries.py
+++ b/fa_search_bot/tests/subscriptions/test_query_parser__queries.py
@@ -17,7 +17,8 @@ from fa_search_bot.subscriptions.query_parser import (
     TitleField,
     WordQuery,
 )
-from fa_search_bot.sites.furaffinity.fa_submission import FAUser, Rating
+from fa_search_bot.sites.furaffinity.fa_submission import FAUser
+from fa_search_bot.sites.submission import Rating
 from fa_search_bot.tests.util.submission_builder import SubmissionBuilder
 
 

--- a/fa_search_bot/tests/subscriptions/test_subscription.py
+++ b/fa_search_bot/tests/subscriptions/test_subscription.py
@@ -1,7 +1,7 @@
 import datetime
 
 from fa_search_bot.subscriptions.query_parser import AndQuery, NotQuery, RatingQuery, WordQuery
-from fa_search_bot.sites.furaffinity.fa_submission import Rating
+from fa_search_bot.sites.submission import Rating
 from fa_search_bot.subscriptions.subscription import Subscription
 from fa_search_bot.tests.util.submission_builder import SubmissionBuilder
 

--- a/fa_search_bot/tests/util/mock_export_api.py
+++ b/fa_search_bot/tests/util/mock_export_api.py
@@ -6,7 +6,8 @@ import string
 from typing import TYPE_CHECKING
 
 from fa_search_bot.sites.furaffinity.fa_export_api import FAExportAPI, PageNotFound
-from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FAUser, Rating
+from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FAUser
+from fa_search_bot.sites.submission import Rating
 
 if TYPE_CHECKING:
     from typing import List, Union

--- a/fa_search_bot/tests/util/submission_builder.py
+++ b/fa_search_bot/tests/util/submission_builder.py
@@ -4,7 +4,8 @@ import datetime
 import random
 from typing import TYPE_CHECKING
 
-from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FASubmissionShort, FAUser, Rating
+from fa_search_bot.sites.furaffinity.fa_submission import FASubmissionFull, FASubmissionShort, FAUser
+from fa_search_bot.sites.submission import Rating
 from fa_search_bot.tests.util.mock_export_api import MockSubmission, _random_image_id, _random_string
 
 if TYPE_CHECKING:


### PR DESCRIPTION
These can then be used by sites other than FA, and they make the scope much more clear.

I did some odd things, like assume titles and descriptions are always lists of strings, but given author and tags were lists of strings, this seemed neater