### PR TITLE
Subscription check perf improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ subscriptions.json*
 # Bot logs and sandbox
 logs/
 sandbox/
+/experiments/perf_profile_submission_data.json
+/experiments/perf_profile_subscriptions.json

--- a/experiments/perf_profile_sub_checker.py
+++ b/experiments/perf_profile_sub_checker.py
@@ -1,0 +1,130 @@
+import asyncio
+import json
+import logging
+import pathlib
+import sys
+
+from prometheus_client.metrics import Summary
+
+from fa_search_bot.config import SubscriptionWatcherConfig
+from fa_search_bot.sites.furaffinity.fa_export_api import FAExportAPI
+from fa_search_bot.subscriptions.query_target import QueryTarget
+from fa_search_bot.subscriptions.query_parser import Query
+from fa_search_bot.subscriptions.subscription_watcher import SubscriptionWatcher
+from fa_search_bot.subscriptions.utils import TimeKeeper
+
+#####
+# This experiment is looking at performance profiling of the subscriptions checker against real world data
+#####
+
+logger = logging.getLogger(__name__)
+time_taken = Summary(
+    "fasearchbot_experiment_perf_time_taken",
+    "Experiment: Not to be used or collected, just using it to power TimeKeeper",
+)
+
+
+def setup_logging(log_level: str = "INFO") -> None:
+    formatter = logging.Formatter("{asctime}:{levelname}:{name}:{message}", style="{")
+
+    base_logger = logging.getLogger()
+    base_logger.setLevel(log_level.upper())
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    base_logger.addHandler(console_handler)
+
+
+async def load_submission_cache(fa_api: FAExportAPI) -> list[QueryTarget]:
+    cache_file = pathlib.Path(__file__).parent / "perf_profile_submission_data.json"
+    try:
+        with open(cache_file, "r") as f:
+            data = json.loads(f.read())
+            subs = [QueryTarget.from_json(sub) for sub in data["submissions"]]
+            return subs
+    except json.decoder.JSONDecodeError:
+        pass
+    except FileNotFoundError:
+        pass
+    browse_page = await fa_api.get_browse_page()
+    query_targets = []
+    for sub_short in browse_page:
+        # noinspection PyBroadException
+        try:
+            sub = await fa_api.get_full_submission(sub_short.submission_id)
+            query_targets.append(sub.to_query_target())
+        except Exception as e:
+            pass
+    with open(cache_file, "w") as f:
+        # noinspection PyTypeChecker
+        json.dump({"submissions": [qt.to_json() for qt in query_targets]}, f, indent=2)
+    return query_targets
+
+
+async def perf_test(sub_watcher: SubscriptionWatcher, submissions: list[QueryTarget]) -> None:
+    for submission in submissions:
+        logger.info("Checking submission titled: %s", submission.title)
+        matches = await sub_watcher.check_subscriptions(submission)
+        logger.info("Submission matches %s subscriptions!!", len(matches))
+
+
+def query_complexity(query: Query) -> float:
+    return repr(query).count("(")
+
+
+def most_complex_queries(queries: list[Query]) -> list[Query]:
+    return sorted(queries, key=query_complexity, reverse=True)
+
+
+def list_queries(sub_watcher: SubscriptionWatcher) -> list[Query]:
+    queries = []
+    for subscription in sub_watcher.subscriptions:
+        queries.append(subscription.query)
+    for dest_blocklist in sub_watcher.blocklists.values():
+        for block in dest_blocklist.blocklists.values():
+            queries.append(block)
+    return queries
+
+
+def load_sub_watcher(fa_api: FAExportAPI) -> SubscriptionWatcher:
+    sub_watcher_config = SubscriptionWatcherConfig(False, 0, 0, 0, 0)
+    subscriptions_file_name = "perf_profile_subscriptions.json"
+    SubscriptionWatcher.FILENAME = subscriptions_file_name
+    SubscriptionWatcher.FILENAME_TEMP = f"{subscriptions_file_name}.temp.json"
+    # noinspection PyTypeChecker
+    sub_watcher = SubscriptionWatcher.load_from_json(sub_watcher_config, fa_api, None, None)
+    if len(sub_watcher.subscriptions) == 0:
+        raise ValueError(f"Failed to load subscriptions, place a subscriptions.json file at {subscriptions_file_name}")
+    return sub_watcher
+
+
+async def main():
+    collate_most_complex = False
+    run_perf_test = True
+    # Set everything up
+    setup_logging(log_level="DEBUG")
+    fa_api = FAExportAPI("https://faexport.spangle.org.uk")
+    try:
+        sub_watcher = load_sub_watcher(fa_api)
+        print(f"There are {len(sub_watcher.subscriptions)} subscriptions")
+        # Collate most complex queries
+        if collate_most_complex:
+            most_complex = most_complex_queries(list_queries(sub_watcher))
+            print("Top 10 most complex queries:")
+            for num, query in enumerate(most_complex[:10]):
+                print(f"{num}: ({query_complexity(query)}) {query!r}")
+            return
+        # Load submissions
+        submissions = await load_submission_cache(fa_api)
+        print(f"There are {len(submissions)} submissions")
+        # Run perf test
+        if run_perf_test:
+            perf_time = TimeKeeper(time_taken)
+            with perf_time.time():
+                await perf_test(sub_watcher, submissions)
+            print(f"Perf test took: {perf_time.duration} seconds")
+    finally:
+        await fa_api.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/fa_search_bot/config.py
+++ b/fa_search_bot/config.py
@@ -8,6 +8,7 @@ DEFAULT_NUM_DATA_FETCHERS = 2
 DEFAULT_NUM_MEDIA_DOWNLOADERS = 2
 DEFAULT_NUM_MEDIA_UPLOADERS = 1
 DEFAULT_MAX_READY_FOR_UPLOAD = 100    # Maximum number of submissions which should be ready for media upload, to prevent data being too stale by the time it comes to upload, especially if catching up on backlog
+DEFAULT_FETCH_REFRESH_LIMIT = 25
 
 
 @dataclasses.dataclass
@@ -47,6 +48,7 @@ class SubscriptionWatcherConfig:
     num_media_downloaders: int
     num_media_uploaders: int
     max_ready_for_upload: int
+    fetch_refresh_limit: int
 
     def total_num_task_runners(self) -> int:
         return self.num_data_fetchers + self.num_media_downloaders + self.num_media_uploaders
@@ -59,6 +61,7 @@ class SubscriptionWatcherConfig:
             num_media_downloaders=conf.get("num_media_downloaders", DEFAULT_NUM_MEDIA_DOWNLOADERS),
             num_media_uploaders=conf.get("num_media_uploaders", DEFAULT_NUM_MEDIA_UPLOADERS),
             max_ready_for_upload=conf.get("max_ready_for_upload", DEFAULT_MAX_READY_FOR_UPLOAD),
+            fetch_refresh_limit=conf.get("fetch_refresh_limit", DEFAULT_FETCH_REFRESH_LIMIT),
         )
 
 

--- a/fa_search_bot/sites/furaffinity/fa_submission.py
+++ b/fa_search_bot/sites/furaffinity/fa_submission.py
@@ -9,7 +9,9 @@ import aiohttp
 import dateutil.parser
 from telethon import Button
 
-from fa_search_bot.sites.submission import Rating, QueryTarget
+from fa_search_bot.sites.submission import Rating
+from fa_search_bot.sites.submission_id import SubmissionID
+from fa_search_bot.subscriptions.query_target import QueryTarget
 
 if TYPE_CHECKING:
     import datetime
@@ -246,6 +248,7 @@ class FASubmissionFull(FASubmissionShort):
 
     def to_query_target(self) -> QueryTarget:
         return QueryTarget(
+            sub_id=SubmissionID("fa", self.submission_id),
             title=[self.title],
             keywords=self.keywords,
             description=[self.description],

--- a/fa_search_bot/sites/submission.py
+++ b/fa_search_bot/sites/submission.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-import dataclasses
 from enum import Enum
 
 
@@ -8,12 +5,3 @@ class Rating(Enum):
     GENERAL = 1
     MATURE = 2
     ADULT = 3
-
-
-@dataclasses.dataclass
-class QueryTarget:
-    title: list[str]
-    keywords: list[str]
-    description: list[str]
-    artist: list[str]
-    rating: Rating

--- a/fa_search_bot/subscriptions/fetch_queue.py
+++ b/fa_search_bot/subscriptions/fetch_queue.py
@@ -71,10 +71,10 @@ class RefreshCounter:
 
 class FetchQueue:
 
-    def __init__(self):
+    def __init__(self, refresh_limit: int = 100):
         self._new_queue: Queue[SubmissionID] = Queue()
         self._refresh_queue: Queue[SubmissionID] = Queue()
-        self.refresh_counter = RefreshCounter(refresh_limit=100)
+        self.refresh_counter = RefreshCounter(refresh_limit=refresh_limit)  # TODO: configurable
 
     def get_nowait(self) -> SubmissionID:
         try:

--- a/fa_search_bot/subscriptions/query_target.py
+++ b/fa_search_bot/subscriptions/query_target.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+import string
+from abc import ABC, abstractmethod
+from functools import lru_cache
+from typing import NewType
+
+from fa_search_bot.sites.submission import Rating
+from fa_search_bot.sites.submission_id import SubmissionID
+
+punctuation = string.punctuation.replace("-", "").replace("_", "")
+punctuation_pattern = r"[\s" + re.escape(punctuation) + "]+"
+not_punctuation_pattern = r"[^\s" + re.escape(punctuation) + "]+"
+boundary_pattern_start = r"(?:^|(?<=[\s" + re.escape(punctuation) + "]))"
+boundary_pattern_end = r"(?:(?=[\s" + re.escape(punctuation) + "])|$)"
+
+
+def _split_text_to_words(text: str) -> list[str]:
+    return re.split(punctuation_pattern, text)
+
+
+def _clean_word_list(words: list[str]) -> list[str]:
+    return [x.lower().strip(punctuation) for x in words]
+
+
+def _split_text_to_cleaned_words(text: str) -> list[str]:
+    return _clean_word_list(_split_text_to_words(text))
+
+
+FieldLocation = NewType("FieldLocation", str)
+
+
+class Field(ABC):
+
+    @classmethod
+    @abstractmethod
+    def get_field(cls, sub: QueryTarget) -> Field:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def words(self) -> list[str]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def texts(self) -> list[str]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def texts_dict(self) -> dict[str, list[str]]:
+        raise NotImplementedError()
+
+
+class SpecificField(Field, ABC):
+    def __init__(self, value: list[str]) -> None:
+        self.value = value
+
+
+class KeywordField(SpecificField):
+    @classmethod
+    def get_field(cls, sub: QueryTarget) -> KeywordField:
+        return sub.keywords
+
+    @lru_cache
+    def words(self) -> list[str]:
+        return _clean_word_list(self.value)
+
+    @lru_cache
+    def texts(self) -> list[str]:
+        return self.value
+
+    @lru_cache
+    def texts_dict(self) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"keyword_{num}"): keyword for num, keyword in enumerate(self.value)}
+
+
+class TitleField(SpecificField):
+    @classmethod
+    def get_field(cls, sub: QueryTarget) -> TitleField:
+        return sub.title
+
+    @lru_cache
+    def words(self) -> list[str]:
+        return sum([_split_text_to_cleaned_words(title) for title in self.value], start=[])
+
+    @lru_cache
+    def texts(self) -> list[str]:
+        return self.value
+
+    @lru_cache
+    def texts_dict(self) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"title_{num}"): title for num, title in enumerate(self.value)}
+
+
+class DescriptionField(SpecificField):
+    @classmethod
+    def get_field(cls, sub: QueryTarget) -> DescriptionField:
+        return sub.description
+
+    @lru_cache
+    def words(self) -> list[str]:
+        return sum([_split_text_to_cleaned_words(desc) for desc in self.value], start=[])
+
+    @lru_cache
+    def texts(self) -> list[str]:
+        return self.value
+
+    @lru_cache
+    def texts_dict(self) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"description_{num}"): desc for num, desc in enumerate(self.value)}
+
+
+class ArtistField(SpecificField):
+    @classmethod
+    def get_field(cls, sub: QueryTarget) -> ArtistField:
+        return sub.artist
+
+    @lru_cache
+    def words(self) -> list[str]:
+        return [artist.lower() for artist in self.value]
+
+    @lru_cache
+    def texts(self) -> list[str]:
+        return self.value
+
+    @lru_cache
+    def texts_dict(self) -> dict[FieldLocation, str]:
+        return {FieldLocation(f"artist_{num}"): artist for num, artist in enumerate(self.value)}
+
+
+class AnyField(Field):
+    def __init__(
+            self,
+            title: TitleField,
+            description: DescriptionField,
+            keyword: KeywordField,
+            artist: ArtistField,
+    ) -> None:
+        self.title = title
+        self.description = description
+        self.keyword = keyword
+        self.artist = artist
+
+    @classmethod
+    def get_field(cls, sub: QueryTarget) -> AnyField:
+        return sub.any_field
+
+    @lru_cache
+    def words(self) -> list[str]:
+        return [
+            *self.title.words(),
+            *self.description.words(),
+            *self.keyword.words(),
+            *self.artist.words(),
+        ]
+
+    @lru_cache
+    def texts(self) -> list[str]:
+        return [
+            *self.title.texts(),
+            *self.description.texts(),
+            *self.keyword.texts(),
+            *self.artist.texts(),
+        ]
+
+    @lru_cache
+    def texts_dict(self) -> dict[FieldLocation, str]:
+        return {
+            **self.title.texts_dict(),
+            **self.description.texts_dict(),
+            **self.keyword.texts_dict(),
+            **self.artist.texts_dict(),
+        }
+
+
+class QueryTarget:
+    def __init__(
+            self,
+            sub_id: SubmissionID,
+            title: list[str],
+            description: list[str],
+            keywords: list[str],
+            artist: list[str],
+            rating: Rating,
+    ) -> None:
+        self.sub_id = sub_id
+        self.title = TitleField(title)
+        self.description = DescriptionField(description)
+        self.keywords = KeywordField(keywords)
+        self.artist = ArtistField(artist)
+        self.rating = rating
+        self.any_field = AnyField(self.title, self.description, self.keywords, self.artist)
+
+    def to_json(self) -> dict:
+        return {
+            "sub_id": self.sub_id.to_inline_code(),
+            "title": self.title.value,
+            "keywords": self.keywords.value,
+            "description": self.description.value,
+            "artist": self.artist.value,
+            "rating": self.rating.name,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict) -> QueryTarget:
+        # noinspection PyTypeChecker
+        rating: Rating = Rating[data["rating"]]
+        return QueryTarget(
+            sub_id=SubmissionID.from_inline_code(data["sub_id"]),
+            title=data["title"],
+            keywords=data["keywords"],
+            description=data["description"],
+            artist=data["artist"],
+            rating=rating,
+        )

--- a/fa_search_bot/subscriptions/subscription.py
+++ b/fa_search_bot/subscriptions/subscription.py
@@ -13,18 +13,23 @@ class DestinationBlocklist:
     def __init__(self, destination: int, blocklists: dict[str, Query]) -> None:
         self.destination = destination
         self.blocklists = blocklists
+        self._combined_query: Optional[Query] = None
 
     def count_blocks(self) -> int:
         return len(self.blocklists)
 
     def add(self, query: str) -> None:
         self.blocklists[query] = parse_query(query)
+        self._combined_query = None
 
     def remove(self, query: str) -> None:
         del self.blocklists[query]
+        self._combined_query = None
 
     def as_combined_query(self) -> Query:
-        return AndQuery([NotQuery(query) for query in self.blocklists.values()])
+        if self._combined_query is None:
+            self._combined_query = AndQuery([NotQuery(query) for query in self.blocklists.values()])
+        return self._combined_query
 
     def to_json(self) -> list[dict[str, str]]:
         return [{"query": query} for query in self.blocklists.keys()]

--- a/fa_search_bot/subscriptions/subscription.py
+++ b/fa_search_bot/subscriptions/subscription.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, Any
 
 import dateutil.parser
 
-from fa_search_bot.sites.submission import QueryTarget
+from fa_search_bot.subscriptions.query_target import QueryTarget
 from fa_search_bot.subscriptions.query_parser import parse_query, Query, AndQuery, NotQuery
 
 

--- a/fa_search_bot/subscriptions/subscription.py
+++ b/fa_search_bot/subscriptions/subscription.py
@@ -56,9 +56,11 @@ class Subscription:
         if self.paused:
             return False
         full_query = self.query
-        if blocklist_query:
-            full_query = AndQuery([self.query, blocklist_query])
-        return full_query.matches_submission(result)
+        if blocklist_query is not None:
+            # Checking this way, rather than constructing an AndQuery, is twice as fast.
+            return self.query.matches_submission(result) and blocklist_query.matches_submission(result)
+            # full_query = AndQuery([self.query, blocklist_query])
+        return self.query.matches_submission(result)
 
     def to_json(self) -> Dict:
         latest_update_str = None

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -148,7 +148,7 @@ class SubscriptionWatcher:
         self.blocklists: dict[int, DestinationBlocklist] = dict()
 
         # Initialise sharing data structures
-        self.wait_pool = WaitPool(self.config.max_ready_for_upload)
+        self.wait_pool = WaitPool(self.config.max_ready_for_upload, self.config.fetch_refresh_limit)
 
         # Initialise runners and tasks
         self.sub_id_gatherer: Optional[SubIDGatherer] = None

--- a/fa_search_bot/subscriptions/subscription_watcher.py
+++ b/fa_search_bot/subscriptions/subscription_watcher.py
@@ -14,7 +14,7 @@ import aiofiles.os
 from prometheus_client import Gauge
 
 from fa_search_bot.config import SubscriptionWatcherConfig
-from fa_search_bot.sites.submission import QueryTarget
+from fa_search_bot.subscriptions.query_target import QueryTarget
 from fa_search_bot.subscriptions.media_downloader import MediaDownloader
 from fa_search_bot.subscriptions.media_uploader import MediaUploader
 from fa_search_bot.subscriptions.runnable import ShutdownError

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -120,7 +120,9 @@ class WaitPool:
         # This reverts a submission back to before any data was fetched about it, and re-queues it for data fetch
         async with self._lock:
             if sub_id not in self.submission_state:
-                self.submission_state[sub_id] = SubmissionCheckState(sub_id)
+                new_sub_id = SubmissionCheckState(sub_id)
+                self.submission_state[sub_id] = new_sub_id
+                self.active_states[sub_id] = new_sub_id
             self.submission_state[sub_id].reset()
             # Don't remove from active states, that would risk a deadlock
             # Re-queue for data fetch refresh

--- a/fa_search_bot/subscriptions/wait_pool.py
+++ b/fa_search_bot/subscriptions/wait_pool.py
@@ -76,11 +76,11 @@ class WaitPool:
     The sender is watching for the next item in the pool which is ready to send
     """
 
-    def __init__(self, max_ready_for_upload: int = DEFAULT_MAX_READY_FOR_UPLOAD) -> None:
+    def __init__(self, max_ready_for_upload: int = DEFAULT_MAX_READY_FOR_UPLOAD, fetch_refresh_limit: int = 100) -> None:
         self.max_ready_for_upload = max_ready_for_upload
         self.submission_state: Dict[SubmissionID, SubmissionCheckState] = {}
         self.active_states: Dict[SubmissionID, SubmissionCheckState] = {}
-        self.fetch_data_queue: FetchQueue = FetchQueue()
+        self.fetch_data_queue: FetchQueue = FetchQueue(fetch_refresh_limit)
         self._lock = Lock()
         self._media_uploading_event = Event()
         self._cache_qsize_download: Optional[int] = None

--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ from prometheus_client import Counter
 
 from fa_search_bot.bot import FASearchBot
 from fa_search_bot.config import Config, DEFAULT_MAX_READY_FOR_UPLOAD, DEFAULT_NUM_DATA_FETCHERS, \
-    DEFAULT_NUM_MEDIA_DOWNLOADERS, DEFAULT_NUM_MEDIA_UPLOADERS
+    DEFAULT_NUM_MEDIA_DOWNLOADERS, DEFAULT_NUM_MEDIA_UPLOADERS, DEFAULT_FETCH_REFRESH_LIMIT
 
 log_entries = Counter(
     "fasearchbot_log_messages_total",
@@ -49,6 +49,7 @@ def setup_logging(log_level: str = "INFO") -> None:
 @click.option("--sub-watcher-media-downloaders", type=int, default=DEFAULT_NUM_MEDIA_DOWNLOADERS, help="Number of MediaDownloader tasks which should spin up in the subscription watcher")
 @click.option("--sub-watcher-media-uploaders", type=int, default=DEFAULT_NUM_MEDIA_UPLOADERS, help="Number of MediaUploader tasks which should spin up in the subscription watcher")
 @click.option("--sub-watcher-max-ready-for-upload", type=int, default=DEFAULT_MAX_READY_FOR_UPLOAD, help="Maximum number of submissions which should have data and media fetched before being uploaded to Telegram, to prevent data being too stale by the time it comes to upload, especially if catching up on backlog")
+@click.option("--fetch-max-data-refresh", type=int, default=DEFAULT_FETCH_REFRESH_LIMIT, help="How many times a submission should get pushed back for data refresh before giving up and declaring the submission media to be broken")
 def main(
         log_level: str,
         no_subscriptions: bool,
@@ -56,6 +57,7 @@ def main(
         sub_watcher_media_downloaders: int,
         sub_watcher_media_uploaders: int,
         sub_watcher_max_ready_for_upload: int,
+        fetch_max_data_refresh: int,
 ) -> None:
     setup_logging(log_level)
     # Construct config and ingest flags
@@ -65,6 +67,7 @@ def main(
     config.subscription_watcher.num_media_downloaders = sub_watcher_media_downloaders
     config.subscription_watcher.num_media_uploaders = sub_watcher_media_uploaders
     config.subscription_watcher.max_ready_for_upload = sub_watcher_max_ready_for_upload
+    config.subscription_watcher.fetch_refresh_limit = fetch_max_data_refresh
     # Create and start the bot
     bot = FASearchBot(config)
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
I did a bunch of performance profiling, and managed to speed this up quite a lot! It was taking 2 seconds to test each submission against all 5000 subscriptions, and then I cut that right down to almost nothing. Some of the changes were obvious enough (like caching the split strings in QueryTargets) and some were less obvious (checking the subscription and blocklist separately, rather than combining into 1 query)
But, it seems good! Nothing too scary or complicated. I was building out of a multi-process worker pool, and then discovered these and they sped it up

This also dropped CPU usage significantly! And speeds everything else up because this is a CPU bound action